### PR TITLE
Luiza story 1102025 add test coverage for defects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
             <version>${jira.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>jta</groupId>
+            <artifactId>jta</artifactId>
+            <version>1.0.1b</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -96,8 +96,12 @@ public class OctaneEntityTypeDescriptor {
         return octaneEntityUrl;
     }
 
-    public String buildTestTabEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId) {
-        return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&tabName=" + getTestTabName();
+    public String buildTestTabEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId, String subtype) {
+        if (("defect").equals(subtype)) {
+            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&configuration={"+ "\"tabName\":" + "\"" + getTestTabName() +"\",\"relation_name\":\"test_to_work_items-gherkin_test-scenario_test-test_automated-test_manual-test_suite-target\"}";
+        } else {
+            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&tabName=" + getTestTabName();
+        }
     }
 
     public String getTestReferenceField() {

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -57,6 +57,7 @@ public class OctaneEntityTypeDescriptor {
      */
     private String testReferenceField;
 
+    private static final String TESTS_URL_FOR_DEFECTS = "&configuration={\"tabName\":\"%s\",\"relation_name\":\"test_to_work_items-gherkin_test-scenario_test-test_automated-test_manual-test_suite-target\"}";
 
     public OctaneEntityTypeDescriptor(String typeName, String alias, String typeAbbreviation, String label, String typeColor, String nameForNavigation, String testTabName, String testReferenceField) {
         this.typeName = typeName;
@@ -98,7 +99,9 @@ public class OctaneEntityTypeDescriptor {
 
     public String buildTestTabEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId, String subtype) {
         if (("defect").equals(subtype)) {
-            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&configuration={"+ "\"tabName\":" + "\"" + getTestTabName() +"\",\"relation_name\":\"test_to_work_items-gherkin_test-scenario_test-test_automated-test_manual-test_suite-target\"}";
+            String defectTestsUrl = String.format(TESTS_URL_FOR_DEFECTS, getTestTabName());
+
+            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + defectTestsUrl;
         } else {
             return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&tabName=" + getTestTabName();
         }

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeManager.java
@@ -26,12 +26,14 @@ public class OctaneEntityTypeManager {
 
     static {
         //TYPE
-        OctaneEntityTypeDescriptor applicationModuleType = new OctaneEntityTypeDescriptor("product_area", "application_module", "AM", "Application Module", "#43e4ff", "product_area", "tests-in-pa", "product_areas");
         OctaneEntityTypeDescriptor featureType = new OctaneEntityTypeDescriptor("feature", null, "F", "Feature", "#e57828", "work_item", "tests_in_backlog", "covered_content");
         OctaneEntityTypeDescriptor storyType = new OctaneEntityTypeDescriptor("story", null, "US", "User Story", "#ffb000", "work_item", "tests_in_backlog", "covered_content");
-        OctaneEntityTypeDescriptor requirementType = new OctaneEntityTypeDescriptor("requirement_document", null, "RD", "Requirement", "#0b8eac", "requirement", "tests_in_requirement", "covered_requirement");
+        OctaneEntityTypeDescriptor defectType = new OctaneEntityTypeDescriptor("defect", null, "D", "Defect", "#b21646", "work_item", "relationships", "covered_content");
 
-        Arrays.asList(applicationModuleType, featureType, storyType, requirementType).forEach(descriptor -> {
+        OctaneEntityTypeDescriptor requirementType = new OctaneEntityTypeDescriptor("requirement_document", null, "RD", "Requirement", "#0b8eac", "requirement", "tests_in_requirement", "covered_requirement");
+        OctaneEntityTypeDescriptor applicationModuleType = new OctaneEntityTypeDescriptor("product_area", "application_module", "AM", "Application Module", "#43e4ff", "product_area", "tests-in-pa", "product_areas");
+
+        Arrays.asList(applicationModuleType, featureType, storyType, requirementType, defectType).forEach(descriptor -> {
             typeDescriptorsByName.put(descriptor.getTypeName(), descriptor);
             typeDescriptorsByLabel.put(descriptor.getLabel(), descriptor);
             if (descriptor.getAlias() != null) {
@@ -39,7 +41,7 @@ public class OctaneEntityTypeManager {
             }
         });
 
-        aggregators.add(new AggregateDescriptor("work_items", Arrays.asList(featureType, storyType)));
+        aggregators.add(new AggregateDescriptor("work_items", Arrays.asList(featureType, storyType, defectType)));
         aggregators.add(new AggregateDescriptor("application_modules", Arrays.asList(applicationModuleType)));
         aggregators.add(new AggregateDescriptor("requirement_documents", Arrays.asList(requirementType)));
     }

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -237,7 +237,8 @@ public class CoverageUiHelper {
                         octaneEntity.put("url", typeDescriptor.buildEntityUrl(spaceConfiguration.getLocationParts().getBaseUrl(),
                                 spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId()));
                         octaneEntity.put("testTabUrl", typeDescriptor.buildTestTabEntityUrl(spaceConfiguration.getLocationParts().getBaseUrl(),
-                                spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId()));
+                                spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId(),
+                                (String) octaneEntity.getFields().get("subtype")));
                         octaneEntity.put("typeAbbreviation", typeDescriptor.getTypeAbbreviation());
                         octaneEntity.put("typeColor", typeDescriptor.getTypeColor());
                         contextMap.put("octaneEntity", octaneEntity);


### PR DESCRIPTION
-adding support for defects
-the link to the tests in Octane will redirect the user to the relations tab -> Covering tests for defects