### PR TITLE
Luiza defect 1107461 skipped added to need attention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microfocus.octane.plugins</groupId>
     <artifactId>jira-octane-quality-insight-plugin</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.7.1</version>
     <organization>
         <name>Micro Focus ALM Octane</name>
         <url>https://www.microfocus.com/en-us/products/alm-octane/overview</url>

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -51,8 +51,8 @@ public class OctaneRestManager {
         String queryParam = queryBuilder.build();
 
         String responseStr = sc.getRestConnector().httpGet(url, Arrays.asList(queryParam), headers).getResponseData();
-        GroupEntityCollection col = OctaneEntityParser.parseGroupCollection(responseStr);
-        return col;
+
+        return OctaneEntityParser.parseGroupCollection(responseStr);
     }
 
     public static GroupEntityCollection getNativeStatusCoverageForRunsWithoutStatus(SpaceConfiguration sc, OctaneEntity octaneEntity, OctaneEntityTypeDescriptor typeDescriptor, long workspaceId) {

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -98,9 +98,9 @@ public class CoverageUiHelper {
         Map<String, GroupEntity> statusId2group = coverage.getGroups().stream().filter(gr -> gr.getValue() != null).collect(Collectors.toMap(g -> ((OctaneEntity) g.getValue()).getId(), Function.identity()));
         coverage.getGroups().stream().filter(gr -> gr.getValue() == null).findFirst();
 
-        //Octane may return on coverage group without status - it will be assigned to skipped status
-        //if already skipped group exist - we will add count to it
-        //if skipped group not exist - we will create new one
+        //Octane may return on coverage group without status - it will be assigned to need attention status
+        //if need attention group already exists - we will add count to it
+        //if need attention group does not exist - we will create new one
         Optional<GroupEntity> groupWithoutStatusOpt = coverage.getGroups().stream().filter(gr -> gr.getValue() == null).findFirst();
         if (groupWithoutStatusOpt.isPresent()) {
             GroupEntityCollection coverageOfRunsWithoutStatus = OctaneRestManager.getNativeStatusCoverageForRunsWithoutStatus(sc, octaneEntity, typeDescriptor, workspaceId);
@@ -113,10 +113,14 @@ public class CoverageUiHelper {
                     appendCountToExistingGroupOrCreateNewOne(statusId2group, convertedStatus, gr.getCount());
                 });
             } else {
-                //if we receive different numbers -> put all not-statused items to skipped
-                appendCountToExistingGroupOrCreateNewOne(statusId2group, skippedStatus.getLogicalName(), groupWithoutStatusOpt.get().getCount());
+                //if we receive different numbers -> put all not-statused items to need attention
+                appendCountToExistingGroupOrCreateNewOne(statusId2group, needAttentionStatus.getLogicalName(), groupWithoutStatusOpt.get().getCount());
             }
         }
+
+        //in order to align with Octane test coverage tooltip
+        //we add skipped category to requires attention
+        addSkippedToRequiresAttention(statusId2group);
 
         int total = statusId2group.values().stream().mapToInt(o -> o.getCount()).sum();
         List<MapBasedObject> groups = statusId2group.entrySet().stream()
@@ -125,6 +129,14 @@ public class CoverageUiHelper {
                 .collect(Collectors.toList());
 
         return groups;
+    }
+
+    private static void addSkippedToRequiresAttention(Map<String, GroupEntity> statusId2group) {
+        if (statusId2group.containsKey(skippedStatus.getLogicalName())) {
+            int skippedCount = statusId2group.get(skippedStatus.getLogicalName()).getCount();
+            appendCountToExistingGroupOrCreateNewOne(statusId2group, needAttentionStatus.getLogicalName(), skippedCount);
+            statusId2group.remove(skippedStatus.getLogicalName());
+        }
     }
 
     private static void appendCountToExistingGroupOrCreateNewOne(Map<String, GroupEntity> statusId2group, String groupName, int count) {

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -121,6 +121,7 @@ public class CoverageUiHelper {
         //in order to align with Octane test coverage tooltip
         //we add skipped category to requires attention
         addSkippedToRequiresAttention(statusId2group);
+        statusId2group.remove(skippedStatus.getLogicalName());
 
         int total = statusId2group.values().stream().mapToInt(o -> o.getCount()).sum();
         List<MapBasedObject> groups = statusId2group.entrySet().stream()
@@ -135,7 +136,6 @@ public class CoverageUiHelper {
         if (statusId2group.containsKey(skippedStatus.getLogicalName())) {
             int skippedCount = statusId2group.get(skippedStatus.getLogicalName()).getCount();
             appendCountToExistingGroupOrCreateNewOne(statusId2group, needAttentionStatus.getLogicalName(), skippedCount);
-            statusId2group.remove(skippedStatus.getLogicalName());
         }
     }
 


### PR DESCRIPTION
defect #1107461 [Jira Plugin] Skipped status should be part of "Requires attention" group status in Jira plugin
link to defect: https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1107461

Problem: test coverage shown by Jira plugin shows skipped category, while Octane tooltip adds this to requires attention group

Solution: kept the group category description as it is returned by the octane request, but added the count to requires attention to align with Octane tooltip. No longer showing skipped category in Jira