### PR TITLE
defect #1122476 [Jira Plugin] Space URL should not include workspace …

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -103,10 +103,10 @@ public class ConfigurationUtil {
         LocationParts locationParts = null;
         try {
             locationParts = parseUiLocation(sco.getLocation());
+            sco.setLocation(locationParts.getKey()); //remove from url what's after sharedspace id
         } catch (Exception e) {
             throw new IllegalArgumentException(e.getMessage());
         }
-
 
         String clientSecret = sco.getClientSecret();
         if (isNew) {
@@ -136,6 +136,7 @@ public class ConfigurationUtil {
                 .setLocationParts(locationParts)
                 .setClientId(sco.getClientId())
                 .setClientSecret(clientSecret);
+
         return sc;
     }
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/LocationParts.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/LocationParts.java
@@ -45,7 +45,7 @@ public class LocationParts {
     @JsonIgnore
     public String getKey() {
         if (key == null) {
-            key = (baseUrl + "?p=" + spaceId).toLowerCase();
+            key = (baseUrl + "/ui/?p=" + spaceId).toLowerCase();
         }
         return key;
     }

--- a/src/main/resources/templates/jira-octane-plugin-admin.vm
+++ b/src/main/resources/templates/jira-octane-plugin-admin.vm
@@ -36,7 +36,7 @@
                 <input type="text" id="location" name="location" class="text medium-long-field required">
                 <div class="error" id="locationError"></div>
                 <div class="description">Enter the URL of your ALM Octane application.
-                    <br/>For example: http://myServer.myCompany.com:8081/ui/?p=1001/1002
+                    <br/>For example: http://myServer.myCompany.com:8081/ui/?p=1001
                 </div>
             </div>
             <div class="field-group">


### PR DESCRIPTION
…id (p=1001/1002) if on create workspace are retrieved all workspaces

- remove from space location url irrelevant parts (what's after shared space id) upon saving the configuration
- change example to not be confusing (you don't need workspace id in the location url of the shared space since you can add a configuration for any workspace from that shared space)