### PR TITLE
defect #1123478 [Jira Plugin] "Entity type" field should be completed…

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
@@ -151,6 +151,7 @@ public class ConfigResource {
         }
 
         try {
+            wco.setOctaneEntityTypes(ConfigurationUtil.getOctaneTypesList(wco, wco.getWorkspaceId()));
             WorkspaceConfiguration wc = ConfigurationUtil.validateRequiredAndConvertToInternal(wco, true);
             wc = ConfigurationManager.getInstance().addWorkspaceConfiguration(wc);
             WorkspaceConfigurationOutgoing outputWco = ConfigurationUtil.convertToOutgoing(wc, getSpaceConfigurationId2Name());
@@ -169,6 +170,7 @@ public class ConfigResource {
 
         try {
             wco.setId(workspaceConfigurationId);
+            wco.setOctaneEntityTypes(ConfigurationUtil.getOctaneTypesList(wco, wco.getWorkspaceId()));
             WorkspaceConfiguration wc = ConfigurationUtil.validateRequiredAndConvertToInternal(wco, false);
             WorkspaceConfiguration updatedWc = ConfigurationManager.getInstance().updateWorkspaceConfiguration(wc);
             WorkspaceConfigurationOutgoing outputWco = ConfigurationUtil.convertToOutgoing(updatedWc, getSpaceConfigurationId2Name());

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -235,7 +235,7 @@ public class ConfigurationUtil {
         }
 
         if (wco.getOctaneEntityTypes().size() == 0) {
-            throw new IllegalArgumentException("Octane entity types are missing");
+            throw new IllegalArgumentException("Octane entity types not found for given workspace and udf");
         }
         if (wco.getJiraProjects().size() == 0) {
             throw new IllegalArgumentException("Jira projects are missing");
@@ -254,7 +254,6 @@ public class ConfigurationUtil {
         validateSpaceConfigurationConnectivity(spaceConfiguration);
 
         validateWorkspace(wco);
-        validateOctaneTypesList(wco, workspaceId);
         validateJiraIssuesList(wco);
         validateJiraProjectKey(wco);
 
@@ -313,20 +312,16 @@ public class ConfigurationUtil {
         }
     }
 
-    private static void validateOctaneTypesList(WorkspaceConfigurationOutgoing wco, long workspaceId) {
+    public static Set<String> getOctaneTypesList(WorkspaceConfigurationOutgoing wco, String workspaceId) {
         String spaceConfigurationId = wco.getSpaceConfigId();
         SpaceConfiguration sc = ConfigurationManager.getInstance().getSpaceConfigurationById(spaceConfigurationId, true).get();
 
-        List<String> octaneEntityTypes = OctaneRestManager.getSupportedOctaneTypes(sc, workspaceId, wco.getOctaneUdf());
-        Set<String> octaneEntityLabels = octaneEntityTypes
+        List<String> octaneEntityTypes = OctaneRestManager.getSupportedOctaneTypes(sc, Long.parseLong(workspaceId), wco.getOctaneUdf());
+
+        return octaneEntityTypes
                 .stream()
                 .map(t -> OctaneEntityTypeManager.getByTypeName(t).getLabel())
                 .collect(Collectors.toSet());
-
-        Set<String> providedEntityTypes = wco.getOctaneEntityTypes();
-        if (providedEntityTypes.stream().anyMatch(e -> !octaneEntityLabels.contains(e.trim()))) {
-            throw new IllegalArgumentException("Octane entity types list is not valid for the given udf and workspace");
-        }
     }
 
     public static Collection<KeyValueItem> getValidWorkspaces(String spaceConfigId, String workspaceConfId) {


### PR DESCRIPTION
… automatically both in UI and REST on Create Workspace

link to defect: https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1123478 

Problem: the list of Octane entity types that contain the given udf are not editable in UI and should also not be via REST API
Solution: get and set the octane entity types list for post/put of workspace configuration from Octane and ignore the list send by user (no longer mandatory in rest calls)