### PR TITLE
defect #1123479 [Jira Plugin] Test connection does not detect that th…

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
@@ -275,7 +275,7 @@ public class ConfigResource {
         try {
             ConfigurationUtil.validateName(sco);
             SpaceConfiguration spaceConfig = ConfigurationUtil.validateRequiredAndConvertToInternal(sco, true);
-            ConfigurationUtil.doSpaceConfigurationUniquenessValidation(spaceConfig);
+            ConfigurationUtil.doSpaceConfigurationUniquenessValidation(spaceConfig, false);
             ConfigurationManager.getInstance().addSpaceConfiguration(spaceConfig);
             return Response.ok(ConfigurationUtil.convertToOutgoing(spaceConfig)).build();
         } catch (IllegalArgumentException e) {
@@ -296,7 +296,7 @@ public class ConfigResource {
             sco.setId(id);
             ConfigurationUtil.validateName(sco);
             SpaceConfiguration spaceConfig = ConfigurationUtil.validateRequiredAndConvertToInternal(sco, false);
-            ConfigurationUtil.doSpaceConfigurationUniquenessValidation(spaceConfig);
+            ConfigurationUtil.doSpaceConfigurationUniquenessValidation(spaceConfig, false);
             SpaceConfiguration updated = ConfigurationManager.getInstance().updateSpaceConfiguration(spaceConfig);
             return Response.ok(ConfigurationUtil.convertToOutgoing(updated)).build();
         } catch (IllegalArgumentException e) {
@@ -333,6 +333,7 @@ public class ConfigResource {
             boolean isNewConfig = StringUtils.isEmpty(spaceConfigurationOutgoing.getId());
             SpaceConfiguration spaceConfig = ConfigurationUtil.validateRequiredAndConvertToInternal(spaceConfigurationOutgoing, isNewConfig);
             ConfigurationUtil.validateSpaceConfigurationConnectivity(spaceConfig);
+            ConfigurationUtil.doSpaceConfigurationUniquenessValidation(spaceConfig, true);
             return Response.ok().build();
         } catch (Exception e) {
             return Response.status(Response.Status.CONFLICT).entity(e.getMessage()).build();

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -150,10 +150,17 @@ public class ConfigurationUtil {
         return sco;
     }
 
-    public static void doSpaceConfigurationUniquenessValidation(SpaceConfiguration spaceConfiguration) {
-        validateSpaceNameIsUnique(spaceConfiguration);
-        validateSpaceUrlIsUnique(spaceConfiguration);
-        //validateSpaceConfigurationConnectivity(spaceConfiguration);
+    public static void doSpaceConfigurationUniquenessValidation(SpaceConfiguration spaceConfiguration, boolean isConnectionTested) {
+        try {
+            validateSpaceNameIsUnique(spaceConfiguration);
+            validateSpaceUrlIsUnique(spaceConfiguration);
+        } catch (IllegalArgumentException ex) {
+            if (isConnectionTested) {
+                throw new IllegalArgumentException("Connection is successful, but the following problem was found: " + ex.getMessage());
+            } else {
+                throw ex;
+            }
+        }
     }
 
     private static void validateSpaceNameIsUnique(SpaceConfiguration spaceConfiguration) {


### PR DESCRIPTION
…e location base is already used when creating a new space

link to defect: https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1123479 

Problem: when in the dialog of adding a new space configuration, you can test connection before saving. If the connection is successful, a green icon is shown, but if you press save and the name/location is not valid, the icon will turn red.

Solution: validate the uniqueness of space name/location on test connection, mentioning in the message if the connectivity can be established but other validations fail.