### PR TITLE
defect #1169104: Spaces/clientIds can no long be saved with only spaces in the name

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -79,21 +79,21 @@ public class ConfigurationUtil {
     }
 
     public static void validateName(SpaceConfigurationOutgoing sco) {
-        if (StringUtils.isEmpty(sco.getName())) {
+        if (StringUtils.isEmpty(sco.getName().trim())) {
             throw new IllegalArgumentException("Space configuration name is required");
         }
 
-        if (sco.getName().length() > 40) {
+        if (sco.getName().trim().length() > 40) {
             throw new IllegalArgumentException("Space configuration name exceeds allowed length (40 characters)");
         }
     }
 
     public static SpaceConfiguration validateRequiredAndConvertToInternal(SpaceConfigurationOutgoing sco, boolean isNew) {
 
-        if (StringUtils.isEmpty(sco.getLocation())) {
+        if (StringUtils.isEmpty(sco.getLocation().trim())) {
             throw new IllegalArgumentException("Location URL is required");
         }
-        if (StringUtils.isEmpty(sco.getClientId())) {
+        if (StringUtils.isEmpty(sco.getClientId().trim())) {
             throw new IllegalArgumentException("Client ID is required");
         }
         if (StringUtils.isEmpty(sco.getClientSecret())) {
@@ -102,7 +102,7 @@ public class ConfigurationUtil {
 
         LocationParts locationParts = null;
         try {
-            locationParts = parseUiLocation(sco.getLocation());
+            locationParts = parseUiLocation(sco.getLocation().trim());
             sco.setLocation(locationParts.getKey()); //remove from url what's after sharedspace id
         } catch (Exception e) {
             throw new IllegalArgumentException(e.getMessage());
@@ -131,10 +131,10 @@ public class ConfigurationUtil {
         //convert
         SpaceConfiguration sc = new SpaceConfiguration()
                 .setId(sco.getId())
-                .setName(sco.getName())
-                .setLocation(sco.getLocation())
+                .setName(sco.getName().trim())
+                .setLocation(sco.getLocation().trim())
                 .setLocationParts(locationParts)
-                .setClientId(sco.getClientId())
+                .setClientId(sco.getClientId().trim())
                 .setClientSecret(clientSecret);
 
         return sc;

--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -261,12 +261,16 @@
         }
 
         //validate
-        var nameValue = $("#name").attr("value");
+        var nameValue = $("#name").attr("value").trim();
+        var locationValue = $("#location").attr("value").trim();
+        var clientIdValue = $("#clientId").attr("value").trim();
+
         var validationFailed = !validateMissingRequiredField(nameValue, "#nameError") ||
             !validateConditionAndUpdateErrorField((nameValue.length <= 40), "Exceeds allowed length (40 characters)", "#nameError");
-        validationFailed = !validateMissingRequiredField($("#location").attr("value"), "#locationError") || validationFailed;
-        validationFailed = !validateMissingRequiredField($("#clientId").attr("value"), "#clientIdError") || validationFailed;
+        validationFailed = !validateMissingRequiredField(locationValue, "#locationError") || validationFailed;
+        validationFailed = !validateMissingRequiredField(clientIdValue, "#clientIdError") || validationFailed;
         validationFailed = !validateMissingRequiredField($("#clientSecret").attr("value"), "#clientSecretError") || validationFailed;
+
         return !validationFailed;
     }
 
@@ -278,9 +282,9 @@
 
         //build model
         var modelForUpdate = {
-            name: $("#name").attr("value"),
-            location: $("#location").attr("value"),
-            clientId: $("#clientId").attr("value"),
+            name: $("#name").attr("value").trim(),
+            location: $("#location").attr("value").trim(),
+            clientId: $("#clientId").attr("value").trim(),
             clientSecret: $("#clientSecret").attr("value")
         };
 
@@ -400,9 +404,9 @@
 
             //build model
             var modelForUpdate = {
-                name: $("#name").attr("value"),
-                location: $("#location").attr("value"),
-                clientId: $("#clientId").attr("value"),
+                name: $("#name").attr("value").trim(),
+                location: $("#location").attr("value").trim(),
+                clientId: $("#clientId").attr("value").trim(),
                 clientSecret: $("#clientSecret").attr("value")
             };
 


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1169104

**PROBLEM**
Space/clientId can be saved with only spaces in the name.

**SOLUTION**
Trim the inputs before validation so the UI will display the message that "Value is missing", and also after validation aswell so the saved names/urls/clientIds strings will not have spaces at the start/end.