### PR TITLE
defect #1190056: make test connection icon dissapear when changing inputs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microfocus.octane.plugins</groupId>
     <artifactId>jira-octane-quality-insight-plugin</artifactId>
-    <version>1.0.8.3</version>
+    <version>1.0.8.4</version>
     <organization>
         <name>Micro Focus ALM Octane</name>
         <url>https://www.microfocus.com/en-us/products/alm-octane/overview</url>

--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -370,6 +370,15 @@
     }
 
     function configureSpaceDialog() {
+        function resetStatusIcon() {
+            statusIconInit("#space-save-status");
+        }
+
+        AJS.$("#name").change(resetStatusIcon);
+        AJS.$("#location").change(resetStatusIcon);
+        AJS.$("#clientId").change(resetStatusIcon);
+        AJS.$("#clientSecret").change(resetStatusIcon);
+
         AJS.$("#show-space-dialog").click(function (e) {
             e.preventDefault();
             showSpaceDialog();


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1190056

**Problem**
Test connection success icon still shows after you alter credentials

**Solution**
Make the test connection icon dissapear if any input is changed