### PR TITLE
defect #1208002: adding condition for max_length of the string

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -129,6 +129,7 @@ public class OctaneRestManager {
         conditions.add(new LogicalQueryPhrase("name", udfName));
         conditions.add(new InQueryPhrase("entity_name", OctaneEntityTypeManager.getSupportedTypes()));
         conditions.add(new LogicalQueryPhrase("field_type", "string"));
+        conditions.add(new LogicalQueryPhrase("max_length", 255));
 
         String queryCondition = OctaneQueryBuilder.create().addQueryConditions(conditions).build();
 


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1208002

Problem
Supported types shouldn't show anything if the udf is long string.

Solution
Added condition for the length of the string type to be only 255.