### PR TITLE
defect #12340008: adding invalid udf now displays an error

### DIFF
--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -489,6 +489,7 @@
                     $("#refreshOctaneEntityTypesSpinner").spinStop();
                     $("#octaneEntityTypes").val(data);
                     validateWorkspaceRequiredFieldsFilled();
+                    validateMissingOctaneSupportedEntityTypes(data, "#octaneEntityTypesError", udfName);
                 }, 1000);
             }).fail(function (request, status, error) {
                 $("#refreshOctaneEntityTypesSpinner").spinStop();
@@ -839,6 +840,10 @@
 
     function validateMissingRequiredField(value, errorSelector) {
         return validateConditionAndUpdateErrorField(value, 'Value is missing', errorSelector);
+    }
+
+    function validateMissingOctaneSupportedEntityTypes(data, errorSelector, udfName) {
+        return validateConditionAndUpdateErrorField(data.length !== 0, "No supported entities were found for mapping field: " + udfName, errorSelector);
     }
 
     function validateConditionAndUpdateErrorField(condition, errorMessage, errorSelector) {


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1234008

**Problem**
When moving out of the textbox, no message is display to inform that the udf is invalid.

**Solution**
Adding an error message for entity types if the udf is invalid.
