### PR TITLE
story 1234010 test coverage changes work items

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneServerVersion.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneServerVersion.java
@@ -1,0 +1,125 @@
+package com.microfocus.octane.plugins.configuration;
+
+import org.apache.commons.lang.Validate;
+
+public class OctaneServerVersion implements Comparable<OctaneServerVersion> {
+
+    private int releaseVersion;
+    private int minorVersion;
+    private int pushNumber;
+    private int buildNumber;
+
+    public OctaneServerVersion(String version) {
+        String[] versionNumbers = version.split("\\.");
+        if ((versionNumbers.length != 3) && (versionNumbers.length != 4)) {
+            throw new RuntimeException(String.format("The version '%s' does not have a correct format", version));
+        }
+        releaseVersion = Integer.parseInt(versionNumbers[0]);
+        minorVersion = Integer.parseInt(versionNumbers[1]);
+        pushNumber = Integer.parseInt(versionNumbers[2]);
+        if (versionNumbers.length == 4) {
+            buildNumber = Integer.parseInt(versionNumbers[3]);
+        } else {
+            buildNumber = Integer.parseInt(PluginConstants.DEFAULT_BUILD);
+        }
+    }
+
+    public int getReleaseVersion() {
+        return releaseVersion;
+    }
+
+    public int getMinorVersion() {
+        return minorVersion;
+    }
+
+    public int getPushNumber() {
+        return pushNumber;
+    }
+
+    public int getBuildNumber() {
+        return buildNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OctaneServerVersion)) return false;
+
+        OctaneServerVersion version = (OctaneServerVersion) o;
+
+        if (releaseVersion != version.releaseVersion) return false;
+        if (minorVersion != version.minorVersion) return false;
+        return pushNumber == version.pushNumber;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = releaseVersion;
+        result = 31 * result + minorVersion;
+        result = 31 * result + pushNumber;
+        return result;
+    }
+
+    @Override
+    //build number is not part of version compare
+    //upgrade is required for push number change or higher
+    public int compareTo(OctaneServerVersion version) {
+        Validate.notNull(version, "Argument should not be null.");
+        if (getReleaseVersion() > version.getReleaseVersion()) {
+            return 1;
+        }
+        if (getReleaseVersion() < version.getReleaseVersion()) {
+            return -1;
+        }
+
+        if (getMinorVersion() > version.getMinorVersion()) {
+            return 1;
+        }
+
+        if (getMinorVersion() < version.getMinorVersion()) {
+            return -1;
+        }
+
+        if (getPushNumber() > version.getPushNumber()) {
+            return 1;
+        }
+
+        if (getPushNumber() < version.getPushNumber()) {
+            return -1;
+        }
+        return 0;
+    }
+
+    public boolean isGreaterThan(OctaneServerVersion version) {
+        return compareTo(version) > 0;
+    }
+
+    public boolean isGreaterOrEqual(OctaneServerVersion version) {
+        return compareTo(version) >= 0;
+    }
+
+    public boolean isLessThan(OctaneServerVersion version) {
+        return compareTo(version) < 0;
+    }
+
+    public boolean isLessOrEqual(OctaneServerVersion version) {
+        return compareTo(version) <= 0;
+    }
+
+    public String getProductVersion() {
+        return releaseVersion + PluginConstants.SEPARATOR +
+                minorVersion + PluginConstants.SEPARATOR +
+                pushNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "Version{" +
+                "releaseVersion=" + releaseVersion +
+                ", minorVersion=" + minorVersion +
+                ", pushNumber='" + pushNumber + '\'' +
+                ", buildNumber=" + buildNumber +
+                '}';
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -13,4 +13,9 @@ public class PluginConstants {
 
     public static String PUBLIC_API_WORKSPACE_FORMAT = PUBLIC_API_SHAREDSPACE_FORMAT + "/workspaces/%s";
     public static String PUBLIC_API_WORKSPACE_LEVEL_ENTITIES = PUBLIC_API_WORKSPACE_FORMAT + "/%s";
+
+    //octane version
+    public static final String DEFAULT_BUILD = "9999";
+    public static final String SEPARATOR = ".";
+    public static final String FUGEES_VERSION = "15.1.90";
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/VersionEntity.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/VersionEntity.java
@@ -1,0 +1,56 @@
+package com.microfocus.octane.plugins.configuration;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class VersionEntity {
+
+    private String version;
+    private String buildDate;
+    private String buildRevision;
+    private String buildNumber;
+    private String displayVersion;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getBuildDate() {
+        return buildDate;
+    }
+
+    @JsonProperty("build_date")
+    public void setBuildDate(String buildDate) {
+        this.buildDate = buildDate;
+    }
+
+    public String getBuildRevision() {
+        return buildRevision;
+    }
+
+    @JsonProperty("build_revision")
+    public void setBuildRevision(String buildRevision) {
+        this.buildRevision = buildRevision;
+    }
+
+    public String getBuildNumber() {
+        return buildNumber;
+    }
+
+    @JsonProperty("build_number")
+    public void setBuildNumber(String buildNumber) {
+        this.buildNumber = buildNumber;
+    }
+
+    public String getDisplayVersion() {
+        return displayVersion;
+    }
+
+    @JsonProperty("display_version")
+    public void setDisplayVersion(String displayVersion) {
+        this.displayVersion = displayVersion;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
@@ -18,11 +18,14 @@ package com.microfocus.octane.plugins.rest;
 import com.atlassian.jira.util.json.JSONArray;
 import com.atlassian.jira.util.json.JSONException;
 import com.atlassian.jira.util.json.JSONObject;
+import com.microfocus.octane.plugins.configuration.VersionEntity;
 import com.microfocus.octane.plugins.rest.entities.OctaneEntity;
 import com.microfocus.octane.plugins.rest.entities.OctaneEntityCollection;
 import com.microfocus.octane.plugins.rest.entities.groups.GroupEntity;
 import com.microfocus.octane.plugins.rest.entities.groups.GroupEntityCollection;
+import org.codehaus.jackson.map.ObjectMapper;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 public class OctaneEntityParser {
@@ -128,5 +131,14 @@ public class OctaneEntityParser {
         }
 
         return groupEntity;
+    }
+
+    public static VersionEntity parseServerVersion(String serverVersion) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(serverVersion, VersionEntity.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse ALM Octane server version:" + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -90,8 +90,8 @@ public class CoverageUiHelper {
         return outputEntity;
     }
 
-    private static List<MapBasedObject> getCoverageGroups(SpaceConfiguration sc, OctaneEntity octaneEntity, OctaneEntityTypeDescriptor typeDescriptor, long workspaceId) {
-        GroupEntityCollection coverage = OctaneRestManager.getCoverage(sc, octaneEntity, typeDescriptor, workspaceId);
+    private static List<MapBasedObject> getCoverageGroups(SpaceConfiguration sc, OctaneEntity octaneEntity, OctaneEntityTypeDescriptor typeDescriptor, long workspaceId, boolean hasSubtype) {
+        GroupEntityCollection coverage = OctaneRestManager.getCoverage(sc, octaneEntity, typeDescriptor, workspaceId, hasSubtype);
         Map<String, GroupEntity> statusId2group = coverage.getGroups().stream().filter(gr -> gr.getValue() != null).collect(Collectors.toMap(g -> ((OctaneEntity) g.getValue()).getId(), Function.identity()));
 
         //Octane may return on coverage group without status - it will be assigned to need attention status
@@ -235,7 +235,7 @@ public class CoverageUiHelper {
 
                         //coverage
                         start = System.currentTimeMillis();
-                        List<MapBasedObject> coverageGroups = getCoverageGroups(spaceConfiguration, octaneEntity, typeDescriptor, workspaceConfig.getWorkspaceId());
+                        List<MapBasedObject> coverageGroups = getCoverageGroups(spaceConfiguration, octaneEntity, typeDescriptor, workspaceConfig.getWorkspaceId(), aggDescriptor.isSubtyped());
                         perfMap.put("coverage", System.currentTimeMillis() - start);
 
                         //fill context map


### PR DESCRIPTION
link to story: https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1234010

Problem: For the latest version of Octane, you can link only runs to backlog items, not necessarily the whole test, so what the plugin was showing would be different from the widget in Octane. 

Solution: based on version, we get the new url form for work items that will align with the view from Octane.
I set up a cache for storing the octane server version for every shared space, for 30 minutes. This was done because he version check needs to be done before computing the coverage for an issue (which happens on every issue refresh)