### PR TITLE
user story #1234009: changed the 'View in Octane' link based on octane server version

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -385,16 +385,4 @@ public class ConfigurationUtil {
 
         return usedJiraProjects;
     }
-
-    public static String getSpaceConfigurationIdByBaseurl(String baseurl, long spaceId) {
-        List<SpaceConfiguration> spaceConfigurations = ConfigurationManager.getInstance().getSpaceConfigurations();
-        if (spaceConfigurations.isEmpty())
-            return "";
-
-        for (SpaceConfiguration sc: spaceConfigurations)
-            if (sc.getLocationParts().getBaseUrl().equals(baseurl) && sc.getLocationParts().getSpaceId() == spaceId)
-                return sc.getId();
-
-        return "";
-    }
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -385,4 +385,16 @@ public class ConfigurationUtil {
 
         return usedJiraProjects;
     }
+
+    public static String getSpaceConfigurationIdByBaseurl(String baseurl, long spaceId) {
+        List<SpaceConfiguration> spaceConfigurations = ConfigurationManager.getInstance().getSpaceConfigurations();
+        if (spaceConfigurations.isEmpty())
+            return "";
+
+        for (SpaceConfiguration sc: spaceConfigurations)
+            if (sc.getLocationParts().getBaseUrl().equals(baseurl) && sc.getLocationParts().getSpaceId() == spaceId)
+                return sc.getId();
+
+        return "";
+    }
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -44,13 +44,13 @@ public class OctaneRestManager {
 
     private static final Logger log = LoggerFactory.getLogger(OctaneRestManager.class);
 
-    private static LoadingCache<String, VersionEntity> versionCache = CacheBuilder
+    private static LoadingCache<SpaceConfiguration, VersionEntity> versionCache = CacheBuilder
             .newBuilder()
             .expireAfterWrite(30, TimeUnit.MINUTES)
-            .build((new CacheLoader<String, VersionEntity>() {
+            .build((new CacheLoader<SpaceConfiguration, VersionEntity>() {
                 @Override
-                public VersionEntity load(@NotNull String spaceConfigId) {
-                    return getOctaneServerVersion(spaceConfigId);
+                public VersionEntity load(@NotNull SpaceConfiguration sc) {
+                    return getOctaneServerVersion(sc);
                 }
             }));
 
@@ -71,7 +71,7 @@ public class OctaneRestManager {
         if (hasSubtype) {
             VersionEntity versionEntity;
             try {
-                versionEntity = versionCache.get(sc.getId());
+                versionEntity = versionCache.get(sc);
             } catch (ExecutionException e) {
                 throw new RuntimeException(e.getMessage());
             }
@@ -88,9 +88,7 @@ public class OctaneRestManager {
         return  getQueryParam(octaneEntity, typeDescriptor);
     }
 
-    public static VersionEntity getOctaneServerVersion(String spaceConfigId) {
-        SpaceConfiguration sc = ConfigurationManager.getInstance().getSpaceConfigurationById(spaceConfigId, true).get();
-
+    public static VersionEntity getOctaneServerVersion(SpaceConfiguration sc) {
         String url = "/admin/server/version";
         Map<String, String> headers = createHeaderMapWithOctaneClientType();
         headers.put(RestConnector.HEADER_ACCEPT, RestConnector.HEADER_APPLICATION_JSON);

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -88,7 +88,7 @@ public class OctaneRestManager {
         return  getQueryParam(octaneEntity, typeDescriptor);
     }
 
-    private static VersionEntity getOctaneServerVersion(String spaceConfigId) {
+    public static VersionEntity getOctaneServerVersion(String spaceConfigId) {
         SpaceConfiguration sc = ConfigurationManager.getInstance().getSpaceConfigurationById(spaceConfigId, true).get();
 
         String url = "/admin/server/version";

--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -19,4 +19,5 @@ public class PluginConstants {
     public static final String DEFAULT_BUILD = "9999";
     public static final String SEPARATOR = ".";
     public static final String FUGEES_VERSION = "15.1.90";
+    public static final String GUNSNROSES_PUSH2 = "16.0.15";
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -19,5 +19,5 @@ public class PluginConstants {
     public static final String DEFAULT_BUILD = "9999";
     public static final String SEPARATOR = ".";
     public static final String FUGEES_VERSION = "15.1.90";
-    public static final String GUNSNROSES_PUSH2 = "16.0.15";
+    public static final String GUNSNROSES_PUSH2 = "16.0.16";
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/SpaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/SpaceConfiguration.java
@@ -20,6 +20,8 @@ import com.microfocus.octane.plugins.rest.RestConnector;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
+import java.util.Objects;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SpaceConfiguration {
 
@@ -97,5 +99,18 @@ public class SpaceConfiguration {
 
     public void clearRestConnector() {
         restConnector = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpaceConfiguration that = (SpaceConfiguration) o;
+        return location.equals(that.location) && locationParts.equals(that.locationParts) && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location, locationParts, id);
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -64,7 +64,7 @@ public class OctaneEntityTypeDescriptor {
      */
     private String indirectCoveringTestsField;
 
-    private static final String TESTS_URL_FOR_DEFECTS = "&configuration={\"tabName\":\"%s\",\"relation_name\":\"test_to_work_items-gherkin_test-scenario_test-test_automated-test_manual-test_suite-target\"}";
+    private static final String TESTS_URL_FOR_DEFECTS = "&configuration={\"tabName\":\"relationships\",\"relation_name\":\"test_to_work_items-gherkin_test-scenario_test-test_automated-test_manual-test_suite-target\"}";
 
     public OctaneEntityTypeDescriptor(String typeName, String alias, String typeAbbreviation, String label, String typeColor, String nameForNavigation, String testTabName, String testReferenceField, String indirectCoveringTestsField) {
         this.typeName = typeName;
@@ -105,17 +105,14 @@ public class OctaneEntityTypeDescriptor {
         return octaneEntityUrl;
     }
 
-    public String buildTestTabEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId, String subtype) {
-        String spaceConfigurationId = ConfigurationUtil.getSpaceConfigurationIdByBaseurl(baseUrl, spaceId);
-        VersionEntity versionEntity = OctaneRestManager.getOctaneServerVersion(spaceConfigurationId);
+    public String buildTestTabEntityUrl(SpaceConfiguration sc, long workspaceId, String entityId, String subtype) {
+        VersionEntity versionEntity = OctaneRestManager.getOctaneServerVersion(sc);
         OctaneServerVersion octaneServerVersion = new OctaneServerVersion(versionEntity.getVersion());
 
         if (("defect").equals(subtype) && octaneServerVersion.isLessThan(new OctaneServerVersion(PluginConstants.GUNSNROSES_PUSH2))) {
-            String defectTestsUrl = String.format(TESTS_URL_FOR_DEFECTS, getTestTabName());
-
-            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + defectTestsUrl;
+            return buildEntityUrl(sc.getLocationParts().getBaseUrl(), sc.getLocationParts().getSpaceId(), workspaceId, entityId) + TESTS_URL_FOR_DEFECTS;
         } else {
-            return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + "&tabName=" + getTestTabName();
+            return buildEntityUrl(sc.getLocationParts().getBaseUrl(), sc.getLocationParts().getSpaceId(), workspaceId, entityId) + "&tabName=" + getTestTabName();
         }
     }
 

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -15,6 +15,8 @@
 
 package com.microfocus.octane.plugins.descriptors;
 
+import com.microfocus.octane.plugins.configuration.*;
+
 public class OctaneEntityTypeDescriptor {
 
     /***
@@ -104,7 +106,11 @@ public class OctaneEntityTypeDescriptor {
     }
 
     public String buildTestTabEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId, String subtype) {
-        if (("defect").equals(subtype)) {
+        String spaceConfigurationId = ConfigurationUtil.getSpaceConfigurationIdByBaseurl(baseUrl, spaceId);
+        VersionEntity versionEntity = OctaneRestManager.getOctaneServerVersion(spaceConfigurationId);
+        OctaneServerVersion octaneServerVersion = new OctaneServerVersion(versionEntity.getVersion());
+
+        if (("defect").equals(subtype) && octaneServerVersion.isLessThan(new OctaneServerVersion(PluginConstants.GUNSNROSES_PUSH2))) {
             String defectTestsUrl = String.format(TESTS_URL_FOR_DEFECTS, getTestTabName());
 
             return buildEntityUrl(baseUrl, spaceId, workspaceId, entityId) + defectTestsUrl;

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeManager.java
@@ -28,7 +28,7 @@ public class OctaneEntityTypeManager {
         //TYPE
         OctaneEntityTypeDescriptor featureType = new OctaneEntityTypeDescriptor("feature", null, "F", "Feature", "#e57828", "work_item", "tests_in_backlog", "covered_content", "work_items_of_last_run");
         OctaneEntityTypeDescriptor storyType = new OctaneEntityTypeDescriptor("story", null, "US", "User Story", "#ffb000", "work_item", "tests_in_backlog", "covered_content", "work_items_of_last_run");
-        OctaneEntityTypeDescriptor defectType = new OctaneEntityTypeDescriptor("defect", null, "D", "Defect", "#b21646", "work_item", "relationships", "covered_content", "work_items_of_last_run");
+        OctaneEntityTypeDescriptor defectType = new OctaneEntityTypeDescriptor("defect", null, "D", "Defect", "#b21646", "work_item", "tests_in_backlog", "covered_content", "work_items_of_last_run");
 
         OctaneEntityTypeDescriptor requirementType = new OctaneEntityTypeDescriptor("requirement_document", null, "RD", "Requirement", "#0b8eac", "requirement", "tests_in_requirement", "covered_requirement", null);
         OctaneEntityTypeDescriptor applicationModuleType = new OctaneEntityTypeDescriptor("product_area", "application_module", "AM", "Application Module", "#43e4ff", "product_area", "tests-in-pa", "product_areas", null);

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -241,9 +241,8 @@ public class CoverageUiHelper {
                         //fill context map
                         octaneEntity.put("url", typeDescriptor.buildEntityUrl(spaceConfiguration.getLocationParts().getBaseUrl(),
                                 spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId()));
-                        octaneEntity.put("testTabUrl", typeDescriptor.buildTestTabEntityUrl(spaceConfiguration.getLocationParts().getBaseUrl(),
-                                spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId(),
-                                (String) octaneEntity.getFields().get("subtype")));
+                        octaneEntity.put("testTabUrl", typeDescriptor.buildTestTabEntityUrl(spaceConfiguration, workspaceConfig.getWorkspaceId(),
+                                octaneEntity.getId(), (String) octaneEntity.getFields().get("subtype")));
                         octaneEntity.put("typeAbbreviation", typeDescriptor.getTypeAbbreviation());
                         octaneEntity.put("typeColor", typeDescriptor.getTypeColor());
                         contextMap.put("octaneEntity", octaneEntity);


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1234009

**Solution** 
Added a check for octane server version. 
If server >= Guns P2 -> redirect to Tests tab
If server < Guns P2 -> redirect to relations tab (as before)