### PR TITLE
defect #1209123: added proper messages for testing localhost servers

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -270,9 +270,13 @@ public class OctaneRestManager {
                 myErrorMessage = "Network exception, proxy settings may be missing or misconfigured.";
             } else if (exc.getMessage().startsWith("Connection timed out")) {
                 myErrorMessage = "Timed out exception, proxy settings may be missing or misconfigured.";
-            }  else if (exc.getMessage().contains("Network Error")) {
+            } else if (exc.getMessage().contains("Network Error")) {
                 myErrorMessage = "Network error, proxy settings may be missing or misconfigured.";
-            }  else if (exc.getCause() != null && exc.getCause() instanceof UnknownHostException) {
+            } else if (exc.getMessage().contains("unable to find valid certification")) {
+                myErrorMessage = "The store does not contain the appropriate certificate.";
+            } else if (exc.getMessage().contains("Request Error (invalid_request)")) {
+                myErrorMessage = "Invalid request, proxy settings may be missing or misconfigured.";
+            } else if (exc.getCause() != null && exc.getCause() instanceof UnknownHostException) {
                 myErrorMessage = "Location is not available.";
             } else {
                 myErrorMessage = exc.getMessage();


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1209123

Problem: When you try to connect to localhost from a jira from another machine, clicking the test connection button from the table will return a html page as a response.

Solution: Added custom messages for handling this types of errors.