### PR TITLE
defect #1492021: add limit and offset to rest calls and solve the max 50 workspaces bug

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -8,6 +8,7 @@ import com.microfocus.octane.plugins.admin.WorkspaceConfigurationOutgoing;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeDescriptor;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeManager;
 import com.microfocus.octane.plugins.rest.RestStatusException;
+import com.microfocus.octane.plugins.rest.entities.OctaneEntity;
 import com.microfocus.octane.plugins.rest.entities.OctaneEntityCollection;
 import com.microfocus.octane.plugins.rest.query.LogicalQueryPhrase;
 import com.microfocus.octane.plugins.rest.query.QueryPhrase;
@@ -341,7 +342,21 @@ public class ConfigurationUtil {
 
         List<QueryPhrase> conditions = Arrays.asList(new LogicalQueryPhrase("activity_level", 0));//only active workspaces
 
-        OctaneEntityCollection workspaces = OctaneRestManager.getEntitiesByCondition(spConfig, PluginConstants.SPACE_CONTEXT, "workspaces", conditions, Arrays.asList("id", "name"));
+        int limit = 50, offset = 0;
+
+        OctaneEntityCollection workspaces = OctaneRestManager.getEntitiesByCondition(spConfig, PluginConstants.SPACE_CONTEXT, "workspaces", conditions, Arrays.asList("id", "name"), limit, null);
+
+        //repeat the call if the total count is higher than the limit (because of the pagination)
+        while (workspaces.getTotalCount() > workspaces.getData().size()) {
+            offset += limit;
+
+            OctaneEntityCollection nextPageOfWorkspaces = OctaneRestManager.getEntitiesByCondition(spConfig, PluginConstants.SPACE_CONTEXT, "workspaces", conditions, Arrays.asList("id", "name"), limit, offset);
+
+            List<OctaneEntity> newWorkspacesDataList = workspaces.getData();
+            newWorkspacesDataList.addAll(nextPageOfWorkspaces.getData());
+
+            workspaces.setData(newWorkspacesDataList);
+        }
 
         return workspaces.getData()
                 .stream()

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -342,7 +342,7 @@ public class ConfigurationUtil {
 
         List<QueryPhrase> conditions = Arrays.asList(new LogicalQueryPhrase("activity_level", 0));//only active workspaces
 
-        int limit = 50, offset = 0;
+        int limit = 500, offset = 0;
 
         OctaneEntityCollection workspaces = OctaneRestManager.getEntitiesByCondition(spConfig, PluginConstants.SPACE_CONTEXT, "workspaces", conditions, Arrays.asList("id", "name"), limit, null);
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -170,9 +170,9 @@ public class OctaneRestManager {
         return new LogicalQueryPhrase(PluginConstants.PATH, path + "*");
     }
 
-    public static OctaneEntityCollection getEntitiesByCondition(SpaceConfiguration sc, long workspaceId, String collectionName, Collection<QueryPhrase> conditions, Collection<String> fields) {
+    public static OctaneEntityCollection getEntitiesByCondition(SpaceConfiguration sc, long workspaceId, String collectionName, Collection<QueryPhrase> conditions, Collection<String> fields, Integer limit, Integer offset) {
 
-        String queryCondition = OctaneQueryBuilder.create().addQueryConditions(conditions).addSelectedFields(fields).build();
+        String queryCondition = OctaneQueryBuilder.create().addQueryConditions(conditions).addSelectedFields(fields).addPageSize(limit).addStartIndex(offset).build();
         String url;
         if (PluginConstants.SPACE_CONTEXT == workspaceId) {
             url = String.format(PluginConstants.PUBLIC_API_SHAREDSPACE_LEVEL_ENTITIES,

--- a/src/main/java/com/microfocus/octane/plugins/rest/query/OctaneQueryBuilder.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/query/OctaneQueryBuilder.java
@@ -65,12 +65,16 @@ public class OctaneQueryBuilder {
     }
 
     public OctaneQueryBuilder addStartIndex(Integer startIndex) {
-        this.startIndex = startIndex;
+        if (startIndex != null) {
+            this.startIndex = startIndex;
+        }
         return this;
     }
 
-    public OctaneQueryBuilder addPageSize(int pageSize) {
-        this.pageSize = pageSize;
+    public OctaneQueryBuilder addPageSize(Integer pageSize) {
+        if (pageSize != null) {
+            this.pageSize = pageSize;
+        }
         return this;
     }
 

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -183,7 +183,7 @@ public class CoverageUiHelper {
                 conditions.add(subTypeCondition);
             }
 
-            OctaneEntityCollection entities = OctaneRestManager.getEntitiesByCondition(sc, wc.getWorkspaceId(), aggrDescriptor.getCollectionName(), conditions, fields);
+            OctaneEntityCollection entities = OctaneRestManager.getEntitiesByCondition(sc, wc.getWorkspaceId(), aggrDescriptor.getCollectionName(), conditions, fields, null, null);
             if (!entities.getData().isEmpty()) {
                 return entities.getData().get(0);
             }


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1492021

**Problem**: Workspace config only showed max 50 workspaces per space

**Solution**: Added limit and offset to the rest calls parameters. Made the limit for workspaces 500 by default and repeat the call if there are more than 500 workspaces