### PR TITLE
Jdk11 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,8 +254,8 @@
     </build>
     <properties>
         <jira.version>8.19.0</jira.version>
-        <amps.version>8.2.3</amps.version>
-        <jira.software.application.version>8.6.0</jira.software.application.version>
+        <amps.version>8.0.2</amps.version>
+        <jira.software.application.version>8.20.0</jira.software.application.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,32 @@
     <name>ALM Octane - Test Management for Jira</name>
     <description>This ALM Octane plugin provides quality status directly on native Jira Epics, Stories, Issues or custom types. Jira users are able to quickly understand issue test status, and are provided a direct link to quality centric views for related tests, test trends, CI history and other associated information / dashboards.</description>
     <packaging>atlassian-plugin</packaging>
+
+    <properties>
+        <jira.version>8.20.7</jira.version>
+        <amps.version>8.0.2</amps.version>
+        <jira.software.application.version>8.20.7</jira.software.application.version>
+        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
+        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <!-- TestKit version 6.x for JIRA 6.x -->
+        <testkit.version>6.3.11</testkit.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release>
+        <spotbugs.version>3.1.9</spotbugs.version>
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+        <atlassian-util-concurrent.version>2.4.1</atlassian-util-concurrent.version>
+        <jaxb-impl.version>2.3.0</jaxb-impl.version>
+        <jaxb-core.version>2.3.0</jaxb-core.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
+        <javax-activation.version>1.1</javax-activation.version>
+        <FastInfoset.version>1.2.1</FastInfoset.version>
+        <jakarta.xml.bind-api.version>4.0.0-RC1</jakarta.xml.bind-api.version>
+        <jvnet.staxex.version>2.1.0-M1</jvnet.staxex.version>
+        <jakarta.activation-api.version>2.1.0-RC1</jakarta.activation-api.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
@@ -252,28 +278,4 @@
             </plugin>
         </plugins>
     </build>
-    <properties>
-        <jira.version>8.20.7</jira.version>
-        <amps.version>8.0.2</amps.version>
-        <jira.software.application.version>8.20.7</jira.software.application.version>
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
-        <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
-        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        <!-- TestKit version 6.x for JIRA 6.x -->
-        <testkit.version>6.3.11</testkit.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
-        <spotbugs.version>3.1.9</spotbugs.version>
-        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-        <atlassian-util-concurrent.version>2.4.1</atlassian-util-concurrent.version>
-        <jaxb-impl.version>2.3.0</jaxb-impl.version>
-        <jaxb-core.version>2.3.0</jaxb-core.version>
-        <jaxb-api.version>2.3.0</jaxb-api.version>
-        <javax-activation.version>1.1</javax-activation.version>
-        <FastInfoset.version>1.2.1</FastInfoset.version>
-        <jakarta.xml.bind-api.version>4.0.0-RC1</jakarta.xml.bind-api.version>
-        <jvnet.staxex.version>2.1.0-M1</jvnet.staxex.version>
-        <jakarta.activation-api.version>2.1.0-RC1</jakarta.activation-api.version>
-    </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,21 @@
     <packaging>atlassian-plugin</packaging>
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.4.0-b180830.0359</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-api</artifactId>
             <version>${jira.version}</version>
@@ -203,7 +218,7 @@
     </build>
     <properties>
         <jira.version>7.13.0</jira.version>
-        <amps.version>8.0.2</amps.version>
+        <amps.version>8.2.3</amps.version>
         <jira.software.application.version>7.9.0</jira.software.application.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
@@ -212,8 +227,9 @@
         <!-- TestKit version 6.x for JIRA 6.x -->
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+<!--        <maven.compiler.source>1.8</maven.compiler.source>-->
+<!--        <maven.compiler.target>1.8</maven.compiler.target>-->
         <spotbugs.version>3.1.9</spotbugs.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,17 +17,19 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <jira.version>8.20.7</jira.version>
-        <amps.version>8.0.2</amps.version>
-        <jira.software.application.version>8.20.7</jira.software.application.version>
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <maven.compiler.release>11</maven.compiler.release>
+
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        <!-- TestKit version 6.x for JIRA 6.x -->
+
+        <jira.version>8.20.7</jira.version>
+        <jira.software.application.version>8.20.7</jira.software.application.version>
+        <amps.version>8.0.2</amps.version>
+
+        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
+        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
         <spotbugs.version>3.1.9</spotbugs.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <atlassian-util-concurrent.version>2.4.1</atlassian-util-concurrent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,19 +17,30 @@
     <packaging>atlassian-plugin</packaging>
     <dependencies>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax.servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${javax-activation.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.4.0-b180830.0359</version>
+            <version>${jaxb-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>3.0.1</version>
+            <version>${jaxb-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>3.0.1</version>
+            <version>${jaxb-impl.version}</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.jira</groupId>
@@ -116,6 +127,11 @@
             <artifactId>gson</artifactId>
             <version>2.2.2-atlassian-1</version>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.util.concurrent</groupId>
+            <artifactId>atlassian-util-concurrent</artifactId>
+            <version>${atlassian-util-concurrent.version}</version>
+        </dependency>
         <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
         <!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->
         <!--
@@ -137,7 +153,7 @@
                 <configuration>
                     <productVersion>${jira.version}</productVersion>
                     <productDataVersion>${jira.version}</productDataVersion>
-                    <jvmArgs>-Xms1g -Xmx1g</jvmArgs>
+                    <jvmArgs>-Xms1g -Xmx1g -XX:+ExplicitGCInvokesConcurrent</jvmArgs>
                     <applications>
                         <application>
                             <applicationKey>jira-software</applicationKey>
@@ -217,9 +233,9 @@
         </plugins>
     </build>
     <properties>
-        <jira.version>7.13.0</jira.version>
+        <jira.version>8.19.0</jira.version>
         <amps.version>8.2.3</amps.version>
-        <jira.software.application.version>7.9.0</jira.software.application.version>
+        <jira.software.application.version>8.6.0</jira.software.application.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
@@ -228,8 +244,12 @@
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-<!--        <maven.compiler.source>1.8</maven.compiler.source>-->
-<!--        <maven.compiler.target>1.8</maven.compiler.target>-->
         <spotbugs.version>3.1.9</spotbugs.version>
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+        <atlassian-util-concurrent.version>2.4.1</atlassian-util-concurrent.version>
+        <jaxb-impl.version>2.3.0</jaxb-impl.version>
+        <jaxb-core.version>2.3.0</jaxb-core.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
+        <javax-activation.version>1.1</javax-activation.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -253,9 +253,9 @@
         </plugins>
     </build>
     <properties>
-        <jira.version>8.19.0</jira.version>
+        <jira.version>8.20.7</jira.version>
         <amps.version>8.0.2</amps.version>
-        <jira.software.application.version>8.20.0</jira.software.application.version>
+        <jira.software.application.version>8.20.7</jira.software.application.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,26 @@
     <packaging>atlassian-plugin</packaging>
     <dependencies>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.fastinfoset</groupId>
+            <artifactId>FastInfoset</artifactId>
+            <version>${FastInfoset.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.staxex</groupId>
+            <artifactId>stax-ex</artifactId>
+            <version>${jvnet.staxex.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>${javax.servlet-api.version}</version>
@@ -251,5 +271,9 @@
         <jaxb-core.version>2.3.0</jaxb-core.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
         <javax-activation.version>1.1</javax-activation.version>
+        <FastInfoset.version>1.2.1</FastInfoset.version>
+        <jakarta.xml.bind-api.version>4.0.0-RC1</jakarta.xml.bind-api.version>
+        <jvnet.staxex.version>2.1.0-M1</jvnet.staxex.version>
+        <jakarta.activation-api.version>2.1.0-RC1</jakarta.activation-api.version>
     </properties>
 </project>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1209110

This US covers:
- Upgrade JDK 8 to JDK 11 
- Add dependencies that were removed in JDK 11 but are still required (for example: jaxb dependency)
- Change jira software and jira core version to a version that also supports jdk 11.
- Add ExplicitGCInvokesConcurrent property to the list of startup parameters. (Rreduces the chance of Jira becoming temporarily unavailable while garbage collection is in progress.)
