### PR TITLE
defect #1905019: remove duplicate tooltip from workspace config

### DIFF
--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -220,6 +220,7 @@
 
     function reloadPossibleJiraFields() {
         function setTitle(text, filled) {
+            AJS.$("#octane-possible-fields-tooltip").tooltip('destroy');
             $("#octane-possible-fields-tooltip").attr("title", text);
             AJS.$("#octane-possible-fields-tooltip").tooltip();
             $("#octane-possible-fields-tooltip").toggleClass("aui-iconfont-info-filled", filled);


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1905019

fix duplicate tooltip

![image](https://user-images.githubusercontent.com/42770621/186687551-d801f19d-270e-4b95-9b4b-6489e6079022.png)

now, the tooltip will close when the text is changed