### PR TITLE
defect #1962496: fix for open issue in new tab/window

### DIFF
--- a/src/main/resources/js/jira-octane-plugin-coverage-panel.js
+++ b/src/main/resources/js/jira-octane-plugin-coverage-panel.js
@@ -1,3 +1,26 @@
+jQuery(document).ready(function() {
+    load(1);
+});
+
+function load(counter) {
+    var panelEl = jQuery("#octane-coverage-panel:not(.resolved)");
+
+    if (!panelEl.length) {
+        if(counter < 30) {
+            setTimeout(function () {
+                load(counter + 1);
+            }, 150);
+        }
+    } else {
+        console.log("[coverage] octane plugin load successfully " + counter);
+        var projectKey = panelEl.attr("project-key");
+        var issueKey = panelEl.attr("issue-key");
+        var issueId = panelEl.attr("issue-id");
+        jQuery("#octane-coverage-panel").addClass("resolved");
+        loadOctaneCoverageWidget(projectKey, issueKey, issueId);
+    }
+}
+
 function loadOctaneCoverageWidget(projectKey, issueKey, issueId) {
     var query = "&project-key=" + projectKey + "&issue-key=" + issueKey + "&issue-id=" + issueId;
     var url = AJS.contextPath() + "/rest/octane-coverage/1.0/coverage?" + query;

--- a/src/main/resources/templates/test-coverage-web-panel.vm
+++ b/src/main/resources/templates/test-coverage-web-panel.vm
@@ -1,27 +1,5 @@
 <script language="JavaScript" type="text/javascript">
-    jQuery(document).ready(function() {
-        console.log("octane plugin : document ready");
-        load(1);
-    });
-
-    function load(counter) {
-        var panelEl = jQuery("#octane-coverage-panel:not(.resolved)");
-
-        if (!panelEl.length) {
-            if(counter < 30) {
-                setTimeout(function () {
-                    load(counter + 1);
-                }, 150);
-            }
-        } else {
-            console.log("load successfully " + counter);
-            var projectKey = panelEl.attr("project-key");
-            var issueKey = panelEl.attr("issue-key");
-            var issueId = panelEl.attr("issue-id");
-            jQuery("#octane-coverage-panel").addClass("resolved");
-            loadOctaneCoverageWidget(projectKey, issueKey, issueId);
-        }
-    };
+    load(1);
 </script>
 
 <div id="octane-coverage-panel" issue-key="$issueKey" issue-id="$issueId" project-key="$projectKey"  class="ghx-container">


### PR DESCRIPTION
- moved load function into the jira-octane-plugin-coverage-panel.js file
- in the VM template file I removed the document ready method because it is loaded every time the issue is changed in the backlog
- added document ready method to the js file so it will load the plugin in all other cases (open issue in detailed view, open in new tab/window)