### PR TITLE
story #2065250: implemented MRJAR for jdk8 & 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <!-- Multi Release JAR properties-->
         <java11-outputdirectory>${project.build.outputDirectory}/META-INF/versions/11</java11-outputdirectory>
         <java11-build-directory>${project.build.directory}/classes-java11</java11-build-directory>
-<!--required to build MRJAR?-->
-        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven.compiler.version>3.11.0</maven.compiler.version>
-<!--END required to build MRJAR-->
+
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
@@ -242,7 +242,6 @@
                             <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
-                    <skipIfEmpty>true</skipIfEmpty>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,15 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <java11-outputdirectory>${project.build.outputDirectory}/META-INF/versions/11</java11-outputdirectory>
+        <java11-build-directory>${project.build.directory}/classes-java11</java11-build-directory>
+<!--required to build MRJAR?-->
+        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven.compiler.version>3.11.0</maven.compiler.version>
+<!--END required to build MRJAR-->
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
@@ -195,6 +201,50 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile-java-8</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-java-11</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>11</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                            </compileSourceRoots>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
                 <artifactId>jira-maven-plugin</artifactId>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2065250

Implemented MRJAR (multi release JAR) for jdk8 and 11 
Project is being created as default for jdk8, with compatibility for jdk11 (this should be the default behavior, because we want base to be as the oldest supported jdk in order to be supported for all customers)
This schema will allow us to have 2 implementations from now on, if desired: for jdk11, we can write jdk11 specific code in src/main/java11, while in src/main/java we'll support only jdk8 specific code. 

When compiled, in META-INF we'll have the code specific to jdk11 and java runtime will know what to load, specific to the version on the machine (on jira with jdk8 will run jdk8 plugin, on jira with jdk11 will run jdk11) 

Compilation of project should remain the same 