### PR TITLE
story #2109026: add new dropdown on coverage for multiple octane workspace configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
                 <configuration>
                     <productVersion>${jira.version}</productVersion>
                     <productDataVersion>${jira.version}</productDataVersion>
-                    <jvmArgs>-Xms512m -Xmx4096m -XX:+ExplicitGCInvokesConcurrent</jvmArgs>
+                    <jvmArgs>-Xms2048m -Xmx4096m -XX:+ExplicitGCInvokesConcurrent</jvmArgs>
                     <extractDependencies>false</extractDependencies>
                     <applications>
                         <application>

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
@@ -19,6 +19,8 @@ import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
+import com.microfocus.octane.plugins.configuration.ConfigurationManager;
+import com.microfocus.octane.plugins.configuration.WorkspaceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +30,10 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
@@ -47,12 +52,49 @@ public class CoverageResource {
     }
 
     @GET
-    public Response getCoverage(@Context HttpServletRequest request, @QueryParam("project-key") String projectKey, @QueryParam("issue-key") String issueKey, @QueryParam("issue-id") String issueId) {
+    public Response getCoverage(@Context HttpServletRequest request, @QueryParam("project-key") String projectKey, @QueryParam("issue-key") String issueKey, @QueryParam("issue-id") String issueId,
+                                @QueryParam("workspace-config-id") String workspaceConfigId, @QueryParam("workspace-id") String workspaceId) {
         UserProfile userProfile = userManager.getRemoteUser(request);
         if (userProfile == null) {
             return Response.status(Response.Status.UNAUTHORIZED).build();
         }
-        Map<String, Object> contextMap = CoverageUiHelper.buildCoverageContextMap(projectKey, issueKey, issueId);
+        Map<String, Object> contextMap = CoverageUiHelper.buildCoverageContextMap(projectKey, issueKey, issueId, workspaceConfigId, workspaceId);
         return Response.ok(contextMap).build();
+    }
+
+    @GET
+    @Path("/octane-workspaces")
+    public Response getOctaneWorkspaces(@Context HttpServletRequest request, @QueryParam("project-key") String projectKey, @QueryParam("issue-type") String issueType) {
+        UserProfile userProfile = userManager.getRemoteUser(request);
+        if (userProfile == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        List<WorkspaceConfiguration> workspaceConfigsForProjectKey = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
+                .filter(wsc -> workspaceConfigContainsProjectAndIssueType(projectKey, issueType, wsc))
+                .collect(Collectors.toList());
+
+        List<Map<String, String>> wsConfigsMap = workspaceConfigsForProjectKey.stream()
+                .map(this::toMap)
+                .collect(Collectors.toList());
+
+        return Response.ok(wsConfigsMap).build();
+    }
+
+    private static boolean workspaceConfigContainsProjectAndIssueType(String projectKey, String issueType, WorkspaceConfiguration workspaceConfiguration) {
+        return workspaceConfiguration.getJiraProjects().stream().anyMatch(jiraProject -> jiraProject.equals(projectKey))
+                && workspaceConfiguration.getJiraIssueTypes().stream().anyMatch(jiraIssueType -> jiraIssueType.equals(issueType));
+    }
+
+    private Map<String, String> toMap(WorkspaceConfiguration wsc) {
+        Map<String, String> map = new HashMap<>();
+
+        map.put("id", wsc.getId());
+        map.put("spaceConfigId", wsc.getSpaceConfigurationId());
+        map.put("spaceConfigName", ConfigurationManager.getInstance().getSpaceConfigurationById(wsc.getSpaceConfigurationId(), false).get().getName());
+        map.put("workspaceId", String.valueOf(wsc.getWorkspaceId()));
+        map.put("workspaceName", wsc.getWorkspaceName());
+
+        return map;
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
@@ -71,7 +71,7 @@ public class CoverageResource {
         }
 
         List<WorkspaceConfiguration> workspaceConfigsForProjectKey = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
-                .filter(wsc -> workspaceConfigContainsProjectAndIssueType(projectKey, issueType, wsc))
+                .filter(wsc -> doesWorkspaceConfigContainsProjectAndIssueType(projectKey, issueType, wsc))
                 .collect(Collectors.toList());
 
         List<Map<String, String>> wsConfigsMap = workspaceConfigsForProjectKey.stream()
@@ -81,7 +81,7 @@ public class CoverageResource {
         return Response.ok(wsConfigsMap).build();
     }
 
-    private static boolean workspaceConfigContainsProjectAndIssueType(String projectKey, String issueType, WorkspaceConfiguration workspaceConfiguration) {
+    private static boolean doesWorkspaceConfigContainsProjectAndIssueType(String projectKey, String issueType, WorkspaceConfiguration workspaceConfiguration) {
         return workspaceConfiguration.getJiraProjects().stream().anyMatch(jiraProject -> jiraProject.equals(projectKey))
                 && workspaceConfiguration.getJiraIssueTypes().stream().anyMatch(jiraIssueType -> jiraIssueType.equals(issueType));
     }

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -168,7 +168,7 @@ public class CoverageUiHelper {
         }
     }
 
-    private static OctaneEntity tryFindMatchingOctaneEntity(SpaceConfiguration sc, WorkspaceConfiguration wc, QueryPhrase jiraKeyCondition, AggregateDescriptor aggrDescriptor) {
+    private static OctaneEntity tryFindMatchingOctaneEntity(SpaceConfiguration sc, String workspaceId, QueryPhrase jiraKeyCondition, AggregateDescriptor aggrDescriptor) {
         try {
             List<QueryPhrase> conditions = new ArrayList<>();
             conditions.add(jiraKeyCondition);
@@ -183,7 +183,7 @@ public class CoverageUiHelper {
                 conditions.add(subTypeCondition);
             }
 
-            OctaneEntityCollection entities = OctaneRestManager.getEntitiesByCondition(sc, wc.getWorkspaceId(), aggrDescriptor.getCollectionName(), conditions, fields, null, null);
+            OctaneEntityCollection entities = OctaneRestManager.getEntitiesByCondition(sc, Long.parseLong(workspaceId), aggrDescriptor.getCollectionName(), conditions, fields, null, null);
             if (!entities.getData().isEmpty()) {
                 return entities.getData().get(0);
             }
@@ -196,7 +196,7 @@ public class CoverageUiHelper {
         return null;
     }
 
-    public static Map<String, Object> buildCoverageContextMap(String projectKey, String issueKey, String issueId) {
+    public static Map<String, Object> buildCoverageContextMap(String projectKey, String issueKey, String issueId, String workspaceConfigId, String workspaceId) {
 
         Map<String, Object> contextMap = new HashMap<>();
         Map<String, Object> debugMap = new HashMap<>();
@@ -206,7 +206,7 @@ public class CoverageUiHelper {
         long startTotal = System.currentTimeMillis();
         //if (configurationManager.isValidConfiguration()) {
         try {
-            WorkspaceConfiguration workspaceConfig = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream().filter(wc -> wc.getJiraProjects().contains(projectKey)).findFirst().get();
+            WorkspaceConfiguration workspaceConfig = ConfigurationManager.getInstance().getWorkspaceConfigurationById(workspaceConfigId, true).get();
             SpaceConfiguration spaceConfiguration = ConfigurationManager.getInstance().getSpaceConfigurationById(workspaceConfig.getSpaceConfigurationId(), true).get();
 
             QueryPhrase jiraKeyCondition = new InQueryPhrase(workspaceConfig.getOctaneUdf(), Arrays.asList(issueKey, issueId.toString()));
@@ -221,7 +221,7 @@ public class CoverageUiHelper {
                 }
                 if (isMatch) {
                     long start = System.currentTimeMillis();
-                    OctaneEntity octaneEntity = tryFindMatchingOctaneEntity(spaceConfiguration, workspaceConfig, jiraKeyCondition, aggDescriptor);
+                    OctaneEntity octaneEntity = tryFindMatchingOctaneEntity(spaceConfiguration, workspaceId, jiraKeyCondition, aggDescriptor);
                     long duration = System.currentTimeMillis() - start;
                     perfMap.put(aggDescriptor.getCollectionName(), duration);
                     if (octaneEntity != null) {

--- a/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanel.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanel.java
@@ -44,6 +44,7 @@ public class TestCoverageWebPanel extends AbstractJiraContextProvider {
         Issue issue = (Issue) jiraHelper.getContextParams().get("issue");
         contextMap.put("issueKey", issue.getKey());
         contextMap.put("issueId", issue.getId());
+        contextMap.put("issueType", issue.getIssueType().getName());
         contextMap.put("projectKey", jiraHelper.getProject().getKey());
 
         return contextMap;

--- a/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanelCondition.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanelCondition.java
@@ -23,8 +23,9 @@ import com.atlassian.plugin.web.Condition;
 import com.microfocus.octane.plugins.configuration.ConfigurationManager;
 import com.microfocus.octane.plugins.configuration.WorkspaceConfiguration;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class TestCoverageWebPanelCondition implements Condition {
 
@@ -42,15 +43,16 @@ public class TestCoverageWebPanelCondition implements Condition {
     @Override
     public boolean shouldDisplay(Map<String, Object> map) {
         Project project = (Project) map.get("project");
-        Optional<WorkspaceConfiguration> workspaceConfigOpt = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
-                .filter(wc -> wc.getJiraProjects().contains(project.getKey())).findFirst();
-        if (workspaceConfigOpt.isPresent()) {
+
+        List<WorkspaceConfiguration> workspaceConfigs = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
+                .filter(wc -> wc.getJiraProjects().contains(project.getKey()))
+                .collect(Collectors.toList());
+
+        if (!workspaceConfigs.isEmpty()) {
             Issue issue = (Issue) map.get("issue");
             String issueType = issue.getIssueType().getName();
-            WorkspaceConfiguration workspaceConfig = workspaceConfigOpt.get();
-            if (workspaceConfig.getJiraIssueTypes().isEmpty() || workspaceConfig.getJiraIssueTypes().contains(issueType)) {
-                return true;
-            }
+
+            return workspaceConfigs.stream().anyMatch(workspaceConfig -> workspaceConfig.getJiraIssueTypes().contains(issueType));
         }
 
         return false;

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -38,6 +38,7 @@
     <context>jira.view.issue</context>
     <context>atl.general</context>
     <dependency>com.atlassian.auiplugin:ajs</dependency>
+    <dependency>com.atlassian.auiplugin:aui-select2</dependency>
     <!--<dependency>com.atlassian.auiplugin:aui-date-picker</dependency>-->
     <resource type="download" name="jira-octane-plugin-coverage-panel.js" location="/js/jira-octane-plugin-coverage-panel.js"/>
     <resource type="download" name="jira-octane-plugin-coverage-panel.css" location="/css/jira-octane-plugin-coverage-panel.css"/>

--- a/src/main/resources/css/jira-octane-plugin-coverage-panel.css
+++ b/src/main/resources/css/jira-octane-plugin-coverage-panel.css
@@ -8,18 +8,22 @@
 }
 
 #octane-entity{
+    width: 100%;
     margin-bottom: 10px;
+    margin-top: 10px;
+    display: inline-flex;
+    align-items: center;
 }
 
 #octane-entity-icon{
     display: inline-block;
+    flex: none;
     position: relative;
     text-align: center;
     vertical-align: middle;
     height: 30px;
     width: 30px;
     border-radius: 50%;
-    margin-top: -2px;
 }
 
 #octane-entity-icon-text {
@@ -31,20 +35,22 @@
 }
 #octane-entity-url{
     margin-left: 5px;
+    margin-right: 5px;
 }
 
 .octane-entity-url2name-splitter {
     color: #cccccc;
     font-size: 20px;
-    line-height: 35px;
+    line-height: 31px;
+    height: 35px;
+    text-align: center;
 }
 
 #octane-entity-name{
+    margin-left: 5px;
     position: relative;
-    top: 4px;
     display: inline-block;
     white-space: nowrap;
-    width: 155px;
     overflow: hidden;
     text-overflow: ellipsis
 }
@@ -112,4 +118,15 @@
     margin-right: 46px;
 }
 
+.width--100 {
+    width: 100%;
+}
+
+.pointer-events--none {
+    pointer-events: none;
+}
+
+.opacity--50 {
+    opacity: 50%;
+}
 

--- a/src/main/resources/templates/test-coverage-web-panel.vm
+++ b/src/main/resources/templates/test-coverage-web-panel.vm
@@ -2,24 +2,27 @@
     load(1);
 </script>
 
-<div id="octane-coverage-panel" issue-key="$issueKey" issue-id="$issueId" project-key="$projectKey"  class="ghx-container">
+<div id="octane-coverage-panel" issue-key="$issueKey" issue-id="$issueId" project-key="$projectKey" issue-type="$issueType" class="ghx-container">
+    <div id="octane-workspaces-dropdown-section">
+        <input type="hidden" name="coverageWorkspaceSelector" id="coverageWorkspaceSelector" class="width--100"/>
+    </div>
     <div id="octane-entity-section" class="hidden">
         <ul class="item-details">
             <!-- octane  entity-->
             <div id="octane-entity">
-                <span id="octane-entity-icon">
-                    <span id="octane-entity-icon-text"></span>
-                </span>
-                <span id="octane-entity-url">
+                <div id="octane-entity-icon">
+                    <div id="octane-entity-icon-text"></div>
+                </div>
+                <div id="octane-entity-url">
                     <a target="_blank"></a>
-                </span>
-                <span class="octane-entity-url2name-splitter">|</span>
-                <span id="octane-entity-name"></span>
+                </div>
+                <div class="octane-entity-url2name-splitter">|</div>
+                <div id="octane-entity-name"></div>
             </div>
 
             <!-- test status-->
             <div id="octane-total-runs"></div>
-            <li>
+            <li id="octane-runs-list">
                 #foreach( $group in $runGroups )
                     <dl id="$group.get("id")" class="hidden">
                         <dt>
@@ -38,18 +41,19 @@
                 #end
             </li>
             <a target="_blank" id="view-tests-in-alm" >View <span id="octane-total-tests"></span> linked tests in ALM Octane</a>
+            <a target="_blank" id="no-linked-tests-in-alm" style="pointer-events: none; cursor: default; color: gray; font-weight: bold" >No linked tests in ALM Octane</a>
 
         </ul>
     </div>
-    <div id="octane-no-data-section" class="hidden">
+    <div id="octane-no-data-section" class="hidden" style="margin-top: 10px">
         <div>No corresponding entity is mapped in ALM Octane.</div>
     </div>
-    <div id="octane-no-valid-configuration-section" class="hidden">
+    <div id="octane-no-valid-configuration-section" class="hidden" style="margin-top: 10px">
         <div>No valid <a href="$configUrl" target="_blank">ALM Octane configuration</a>.</div>
     </div>
     <div id="octane-debug-section" class="hidden">
     </div>
-    <div id="octane-loading-section">
+    <div id="octane-loading-section" style="margin-top: 10px">
         <p>Loading ...<span class="aui-icon aui-icon-wait" style="margin-left: 10px;"></span></p>
     </div>
 </div>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2109026

- added new dropdown on the coverage widget for selecting the available octane workspaces that were configured for current project
![image](https://user-images.githubusercontent.com/42770621/230336641-f0f36c07-9f85-49bd-8866-95a3cca94549.png)

- in the dropdown you'll see the octane workspaces like this: **_octane_workspace_name (jira_space_configuration_name)_**
![image](https://user-images.githubusercontent.com/42770621/230336543-13d23d92-2d85-4669-aff9-8016ea916b9c.png)

- if the dropdown contains only one entry it will be disabled
- the dropdown will be also disabled when changing an entity (while the data is gathered from octane)
- added new endpoint on CoverageResource to get the octane workspaces needed in the dropdown (+they are filtered by project-key and issue type)
- changed the condition to show the coverage on the jira page from verifying the first found workspace configuration that contains the current project-key to checking all of them (TestCoverageWebPanelCondition)
- changed a little bit the styling of the entity shown on the coverage