### PR TITLE
story #2105064: adapt configuration to support multi-workspaces for the same workspace configuration

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/admin/ConfigResource.java
@@ -368,11 +368,11 @@ public class ConfigResource {
         }
     }
 
-    private boolean doesWorkspaceConfigurationAlreadyExists(WorkspaceConfiguration wc) {
+    private boolean doesWorkspaceConfigurationAlreadyExists(WorkspaceConfiguration wscToBeAdded) {
         return ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
-                .anyMatch(wsc -> wsc.getSpaceConfigurationId().equals(wc.getSpaceConfigurationId()) &&
-                        wsc.getOctaneConfigGrouping().equals(wc.getOctaneConfigGrouping()) &&
-                        wsc.getJiraConfigGrouping().equals(wc.getJiraConfigGrouping()));
+                .anyMatch(wsc -> wsc.getSpaceConfigurationId().equals(wscToBeAdded.getSpaceConfigurationId()) &&
+                        wsc.getOctaneConfigGrouping().equals(wscToBeAdded.getOctaneConfigGrouping()) &&
+                        wsc.getJiraConfigGrouping().equals(wscToBeAdded.getJiraConfigGrouping()));
     }
 
     private boolean hasPermission() {

--- a/src/main/java/com/microfocus/octane/plugins/admin/WorkspaceConfigurationOutgoing.java
+++ b/src/main/java/com/microfocus/octane/plugins/admin/WorkspaceConfigurationOutgoing.java
@@ -34,11 +34,8 @@ public class WorkspaceConfigurationOutgoing {
     @XmlElement(name = "spaceConfigName")
     private String spaceConfigName;
 
-    @XmlElement(name = "workspaceId")
-    private String workspaceId;
-
-    @XmlElement(name = "workspaceName")
-    private String workspaceName;
+    @XmlElement(name = "workspaces")
+    private Set<String> workspaces;
 
     @XmlElement(name = "octaneUdf")
     private String octaneUdf;
@@ -52,49 +49,58 @@ public class WorkspaceConfigurationOutgoing {
     @XmlElement(name = "jiraProjects")
     private Set<String> jiraProjects;
 
+    public WorkspaceConfigurationOutgoing() {
+    }
+
+    public WorkspaceConfigurationOutgoing(String id, String spaceConfigId, String spaceConfigName, Set<String> workspaces, String octaneUdf, Set<String> octaneEntityTypes, Set<String> jiraIssueTypes, Set<String> jiraProjects) {
+        this.id = id;
+        this.spaceConfigId = spaceConfigId;
+        this.spaceConfigName = spaceConfigName;
+        this.workspaces = workspaces;
+        this.octaneUdf = octaneUdf;
+        this.octaneEntityTypes = octaneEntityTypes;
+        this.jiraIssueTypes = jiraIssueTypes;
+        this.jiraProjects = jiraProjects;
+    }
+
     public String getId() {
         return id;
     }
 
-    public WorkspaceConfigurationOutgoing setId(String id) {
+    public void setId(String id) {
         this.id = id;
-        return this;
     }
 
     public String getOctaneUdf() {
         return octaneUdf;
     }
 
-    public WorkspaceConfigurationOutgoing setOctaneUdf(String octaneUdf) {
+    public void setOctaneUdf(String octaneUdf) {
         this.octaneUdf = octaneUdf;
-        return this;
     }
 
     public Set<String> getOctaneEntityTypes() {
         return octaneEntityTypes;
     }
 
-    public WorkspaceConfigurationOutgoing setOctaneEntityTypes(Set<String> octaneEntityTypes) {
+    public void setOctaneEntityTypes(Set<String> octaneEntityTypes) {
         this.octaneEntityTypes = octaneEntityTypes;
-        return this;
     }
 
     public Set<String> getJiraIssueTypes() {
         return jiraIssueTypes;
     }
 
-    public WorkspaceConfigurationOutgoing setJiraIssueTypes(Set<String> jiraIssueTypes) {
+    public void setJiraIssueTypes(Set<String> jiraIssueTypes) {
         this.jiraIssueTypes = jiraIssueTypes;
-        return this;
     }
 
     public Set<String> getJiraProjects() {
         return jiraProjects;
     }
 
-    public WorkspaceConfigurationOutgoing setJiraProjects(Set<String> jiraProjects) {
+    public void setJiraProjects(Set<String> jiraProjects) {
         this.jiraProjects = jiraProjects;
-        return this;
     }
 
 
@@ -102,35 +108,23 @@ public class WorkspaceConfigurationOutgoing {
         return spaceConfigId;
     }
 
-    public WorkspaceConfigurationOutgoing setSpaceConfigId(String spaceConfigId) {
+    public void setSpaceConfigId(String spaceConfigId) {
         this.spaceConfigId = spaceConfigId;
-        return this;
     }
 
     public String getSpaceConfigName() {
         return spaceConfigName;
     }
 
-    public WorkspaceConfigurationOutgoing setSpaceConfigName(String spaceConfigName) {
+    public void setSpaceConfigName(String spaceConfigName) {
         this.spaceConfigName = spaceConfigName;
-        return this;
     }
 
-    public String getWorkspaceId() {
-        return workspaceId;
+    public Set<String> getWorkspaces() {
+        return workspaces;
     }
 
-    public WorkspaceConfigurationOutgoing setWorkspaceId(String workspaceId) {
-        this.workspaceId = workspaceId;
-        return this;
-    }
-
-    public String getWorkspaceName() {
-        return workspaceName;
-    }
-
-    public WorkspaceConfigurationOutgoing setWorkspaceName(String workspaceName) {
-        this.workspaceName = workspaceName;
-        return this;
+    public void setWorkspaces(Set<String> workspaces) {
+        this.workspaces = workspaces;
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationManagerConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationManagerConstants.java
@@ -1,0 +1,15 @@
+package com.microfocus.octane.plugins.configuration;
+
+public class ConfigurationManagerConstants {
+
+    public static final String PLUGIN_PREFIX = "com.microfocus.octane.plugins.";
+
+    public static final String CONFIGURATION_KEY_V1 = PLUGIN_PREFIX + "configuration";
+    public static final String CONFIGURATION_KEY_V2 = PLUGIN_PREFIX + "configuration_v2";
+    public static final String CONFIGURATION_KEY_V3 = PLUGIN_PREFIX + "configuration_v3";
+    public static final String USER_FILTER_KEY = PLUGIN_PREFIX + "user.filter";
+
+    public static final String MESSAGE_CHANNEL = "OCTANE_CONFIG";
+
+    public static final int CONFIGURATION_HARD_LIMIT_SIZE = 99000;
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneRestManager.java
@@ -19,6 +19,7 @@ import com.atlassian.util.concurrent.NotNull;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.microfocus.octane.plugins.configuration.v3.SpaceConfiguration;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeDescriptor;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeManager;
 import com.microfocus.octane.plugins.rest.OctaneEntityParser;
@@ -190,7 +191,7 @@ public class OctaneRestManager {
         return col;
     }
 
-    public static List<String> getSupportedOctaneTypes(SpaceConfiguration sc, long workspaceId, String udfName) {
+    public static Set<String> getSupportedOctaneTypes(SpaceConfiguration sc, long workspaceId, String udfName) {
         long spaceId = sc.getLocationParts().getSpaceId();
         String entityCollectionUrl = String.format(PluginConstants.PUBLIC_API_WORKSPACE_LEVEL_ENTITIES, spaceId, workspaceId, "metadata/fields");
         Map<String, String> headers = createHeaderMapWithOctaneClientType();
@@ -206,7 +207,7 @@ public class OctaneRestManager {
 
         String entitiesCollectionStr = sc.getRestConnector().httpGet(entityCollectionUrl, Arrays.asList(queryCondition), headers).getResponseData();
         OctaneEntityCollection fields = OctaneEntityParser.parseCollection(entitiesCollectionStr);
-        List<String> foundTypes = fields.getData().stream().map(e -> e.getString("entity_name")).collect(Collectors.toList());
+        Set<String> foundTypes = fields.getData().stream().map(e -> e.getString("entity_name")).collect(Collectors.toSet());
 
         return foundTypes;
     }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/OctaneWorkspace.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/OctaneWorkspace.java
@@ -1,0 +1,57 @@
+package com.microfocus.octane.plugins.configuration;
+
+import java.util.Objects;
+
+public class OctaneWorkspace {
+
+    private String id;
+    private String name;
+
+    public OctaneWorkspace() {
+    }
+
+    public OctaneWorkspace(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+
+        result = 31 * result + id.hashCode();
+        result = 31 * result + name.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (that == null || that.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final OctaneWorkspace other = (OctaneWorkspace) that;
+        if (!Objects.equals(this.id, other.id) || !Objects.equals(this.name, other.name)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/ConfigurationCollectionV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/ConfigurationCollectionV2.java
@@ -1,0 +1,57 @@
+/*
+ *     Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package com.microfocus.octane.plugins.configuration.v2;
+
+import com.microfocus.octane.plugins.rest.ProxyConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigurationCollectionV2 {
+
+    private List<SpaceConfigurationV2> spaces = new ArrayList<>();
+    private List<WorkspaceConfigurationV2> workspaces = new ArrayList<>();
+    private ProxyConfiguration proxy;
+
+    public List<SpaceConfigurationV2> getSpaces() {
+        return spaces;
+    }
+
+    public List<WorkspaceConfigurationV2> getWorkspaces() {
+        return workspaces;
+    }
+
+    public void setSpaces(List<SpaceConfigurationV2> spaces) {
+        if (spaces == null) {
+            spaces = new ArrayList<>();
+        }
+        this.spaces = spaces;
+    }
+
+    public void setWorkspaces(List<WorkspaceConfigurationV2> workspaces) {
+        if (workspaces == null) {
+            workspaces = new ArrayList<>();
+        }
+        this.workspaces = workspaces;
+    }
+
+    public ProxyConfiguration getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(ProxyConfiguration proxy) {
+        this.proxy = proxy;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/SpaceConfigurationV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/SpaceConfigurationV2.java
@@ -13,9 +13,11 @@
  *     limitations under the License.
  */
 
-package com.microfocus.octane.plugins.configuration;
+package com.microfocus.octane.plugins.configuration.v2;
 
 
+import com.microfocus.octane.plugins.configuration.LocationParts;
+import com.microfocus.octane.plugins.configuration.OctaneRestManager;
 import com.microfocus.octane.plugins.rest.RestConnector;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
@@ -23,7 +25,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SpaceConfiguration {
+public class SpaceConfigurationV2 {
 
     private String name;
     private String location;
@@ -39,7 +41,7 @@ public class SpaceConfiguration {
         return location;
     }
 
-    public SpaceConfiguration setLocation(String location) {
+    public SpaceConfigurationV2 setLocation(String location) {
         this.location = location;
         return this;
     }
@@ -48,7 +50,7 @@ public class SpaceConfiguration {
         return clientSecret;
     }
 
-    public SpaceConfiguration setClientSecret(String clientSecret) {
+    public SpaceConfigurationV2 setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
         return this;
     }
@@ -57,7 +59,7 @@ public class SpaceConfiguration {
         return clientId;
     }
 
-    public SpaceConfiguration setClientId(String clientId) {
+    public SpaceConfigurationV2 setClientId(String clientId) {
         this.clientId = clientId;
         return this;
     }
@@ -66,7 +68,7 @@ public class SpaceConfiguration {
         return id;
     }
 
-    public SpaceConfiguration setId(String id) {
+    public SpaceConfigurationV2 setId(String id) {
         this.id = id;
         return this;
     }
@@ -75,7 +77,7 @@ public class SpaceConfiguration {
         return locationParts;
     }
 
-    public SpaceConfiguration setLocationParts(LocationParts locationParts) {
+    public SpaceConfigurationV2 setLocationParts(LocationParts locationParts) {
         this.locationParts = locationParts;
         return this;
     }
@@ -84,7 +86,7 @@ public class SpaceConfiguration {
         return name;
     }
 
-    public SpaceConfiguration setName(String name) {
+    public SpaceConfigurationV2 setName(String name) {
         this.name = name;
         return this;
     }
@@ -105,7 +107,7 @@ public class SpaceConfiguration {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SpaceConfiguration that = (SpaceConfiguration) o;
+        SpaceConfigurationV2 that = (SpaceConfigurationV2) o;
         return location.equals(that.location) && locationParts.equals(that.locationParts) && id.equals(that.id);
     }
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/WorkspaceConfigurationV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/WorkspaceConfigurationV2.java
@@ -13,21 +13,23 @@
  *     limitations under the License.
  */
 
-package com.microfocus.octane.plugins.configuration;
+package com.microfocus.octane.plugins.configuration.v2;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class WorkspaceConfiguration {
+public class WorkspaceConfigurationV2 {
 
     private String id;
     private String spaceConfigurationId;
+
     private long workspaceId;
-    private String workspaceName;
+    private String workspaceName; //OctaneWorkspace
     private String octaneUdf;
-    private Set<String> octaneEntityTypes;
+    private Set<String> octaneEntityTypes; //OctaneConfiguration
+
     private Set<String> jiraIssueTypes;
     private Set<String> jiraProjects;
 
@@ -35,7 +37,7 @@ public class WorkspaceConfiguration {
         return workspaceId;
     }
 
-    public WorkspaceConfiguration setWorkspaceId(long workspaceId) {
+    public WorkspaceConfigurationV2 setWorkspaceId(long workspaceId) {
         this.workspaceId = workspaceId;
         return this;
     }
@@ -44,7 +46,7 @@ public class WorkspaceConfiguration {
         return octaneUdf;
     }
 
-    public WorkspaceConfiguration setOctaneUdf(String octaneUdf) {
+    public WorkspaceConfigurationV2 setOctaneUdf(String octaneUdf) {
         this.octaneUdf = octaneUdf;
         return this;
     }
@@ -53,7 +55,7 @@ public class WorkspaceConfiguration {
         return octaneEntityTypes;
     }
 
-    public WorkspaceConfiguration setOctaneEntityTypes(Set<String> octaneEntityTypes) {
+    public WorkspaceConfigurationV2 setOctaneEntityTypes(Set<String> octaneEntityTypes) {
         this.octaneEntityTypes = octaneEntityTypes;
         return this;
     }
@@ -62,7 +64,7 @@ public class WorkspaceConfiguration {
         return jiraIssueTypes;
     }
 
-    public WorkspaceConfiguration setJiraIssueTypes(Set<String> jiraIssueTypes) {
+    public WorkspaceConfigurationV2 setJiraIssueTypes(Set<String> jiraIssueTypes) {
         this.jiraIssueTypes = jiraIssueTypes;
         return this;
     }
@@ -71,7 +73,7 @@ public class WorkspaceConfiguration {
         return jiraProjects;
     }
 
-    public WorkspaceConfiguration setJiraProjects(Set<String> jiraProjects) {
+    public WorkspaceConfigurationV2 setJiraProjects(Set<String> jiraProjects) {
         this.jiraProjects = jiraProjects;
         return this;
     }
@@ -80,7 +82,7 @@ public class WorkspaceConfiguration {
         return workspaceName;
     }
 
-    public WorkspaceConfiguration setWorkspaceName(String workspaceName) {
+    public WorkspaceConfigurationV2 setWorkspaceName(String workspaceName) {
         this.workspaceName = workspaceName;
         return this;
     }
@@ -89,7 +91,7 @@ public class WorkspaceConfiguration {
         return id;
     }
 
-    public WorkspaceConfiguration setId(String id) {
+    public WorkspaceConfigurationV2 setId(String id) {
         this.id = id;
         return this;
     }
@@ -98,7 +100,7 @@ public class WorkspaceConfiguration {
         return spaceConfigurationId;
     }
 
-    public WorkspaceConfiguration setSpaceConfigurationId(String spaceConfigurationId) {
+    public WorkspaceConfigurationV2 setSpaceConfigurationId(String spaceConfigurationId) {
         this.spaceConfigurationId = spaceConfigurationId;
         return this;
     }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/upgrader/UpgraderFromV1ToV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/upgrader/UpgraderFromV1ToV2.java
@@ -1,0 +1,88 @@
+package com.microfocus.octane.plugins.configuration.v2.upgrader;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.microfocus.octane.plugins.configuration.ConfigurationUtil;
+import com.microfocus.octane.plugins.configuration.LocationParts;
+import com.microfocus.octane.plugins.configuration.v1.ConfigurationCollectionV1;
+import com.microfocus.octane.plugins.configuration.v1.SpaceConfigurationV1;
+import com.microfocus.octane.plugins.configuration.v2.ConfigurationCollectionV2;
+import com.microfocus.octane.plugins.configuration.v2.SpaceConfigurationV2;
+import com.microfocus.octane.plugins.configuration.v2.WorkspaceConfigurationV2;
+import com.microfocus.octane.plugins.tools.JsonHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static com.microfocus.octane.plugins.configuration.ConfigurationManagerConstants.*;
+
+public class UpgraderFromV1ToV2 {
+
+    private static final Logger log = LoggerFactory.getLogger(UpgraderFromV1ToV2.class);
+
+    public static void upgradeConfigurationFromV1ToV2(PluginSettings settings, PluginSettingsFactory pluginSettingsFactory) {
+        ConfigurationCollectionV2 tempConfiguration = null;
+        String confStrV1 = ((String) settings.get(CONFIGURATION_KEY_V1));
+
+        if (confStrV1 != null) {
+            try {
+                ConfigurationCollectionV1 configurationV1 = JsonHelper.deserialize(confStrV1, ConfigurationCollectionV1.class);
+
+                if (configurationV1.getSpaces().size() == 1) {
+                    SpaceConfigurationV1 scV1 = configurationV1.getSpaces().get(0);
+                    LocationParts locationParts = ConfigurationUtil.parseUiLocation(scV1.getLocation());
+
+                    SpaceConfigurationV2 sc = new SpaceConfigurationV2()
+                            .setId(UUID.randomUUID().toString())
+                            .setClientId(scV1.getClientId())
+                            .setClientSecret(scV1.getClientSecret())
+                            .setLocation(scV1.getLocation())
+                            .setLocationParts(locationParts)
+                            .setName(locationParts.getKey());
+
+                    List<WorkspaceConfigurationV2> wcList = new ArrayList<>();
+                    configurationV1.getSpaces().get(0).getWorkspaces().forEach(w -> {
+                        WorkspaceConfigurationV2 wc = new WorkspaceConfigurationV2()
+                                .setId(UUID.randomUUID().toString())
+                                .setJiraIssueTypes(w.getJiraIssueTypes())
+                                .setJiraProjects(w.getJiraProjects())
+                                .setOctaneEntityTypes(w.getOctaneEntityTypes())
+                                .setOctaneUdf(w.getOctaneUdf())
+                                .setWorkspaceId(w.getWorkspaceId())
+                                .setWorkspaceName(w.getWorkspaceName())
+                                .setSpaceConfigurationId(sc.getId());
+                        wcList.add(wc);
+                    });
+
+                    tempConfiguration = new ConfigurationCollectionV2();
+                    tempConfiguration.setSpaces(new ArrayList<>(Arrays.asList(sc)));
+                    tempConfiguration.setWorkspaces(wcList);
+
+                    if (configurationV1.getProxy() != null) {
+                        tempConfiguration.setProxy(configurationV1.getProxy());
+                        tempConfiguration.getProxy().setNonProxyHost("");
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed tryConvertFromConfigurationV1ToV2: " + e.getMessage());
+            }
+        }
+
+        persistConfigurationV2(tempConfiguration, pluginSettingsFactory);
+    }
+
+    private static void persistConfigurationV2(ConfigurationCollectionV2 configuration, PluginSettingsFactory pluginSettingsFactory) {
+        String confStr = JsonHelper.serialize(configuration);
+
+        if (confStr.length() >= CONFIGURATION_HARD_LIMIT_SIZE) {
+            throw new RuntimeException("Configuration file exceeds hard limit size of " + CONFIGURATION_HARD_LIMIT_SIZE + " characters");
+        }
+
+        PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+        settings.put(CONFIGURATION_KEY_V2, confStr);
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/ConfigurationCollection.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/ConfigurationCollection.java
@@ -12,7 +12,7 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
-package com.microfocus.octane.plugins.configuration;
+package com.microfocus.octane.plugins.configuration.v3;
 
 import com.microfocus.octane.plugins.rest.ProxyConfiguration;
 
@@ -24,6 +24,9 @@ public class ConfigurationCollection {
     private List<SpaceConfiguration> spaces = new ArrayList<>();
     private List<WorkspaceConfiguration> workspaces = new ArrayList<>();
     private ProxyConfiguration proxy;
+
+    public ConfigurationCollection() {
+    }
 
     public List<SpaceConfiguration> getSpaces() {
         return spaces;

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/JiraConfigGrouping.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/JiraConfigGrouping.java
@@ -1,0 +1,60 @@
+package com.microfocus.octane.plugins.configuration.v3;
+
+import com.microfocus.octane.plugins.configuration.OctaneWorkspace;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class JiraConfigGrouping {
+
+    private Set<String> projectNames;
+    private Set<String> issueTypes;
+
+    public JiraConfigGrouping() {
+    }
+
+    public JiraConfigGrouping(Set<String> projectNames, Set<String> issueTypes) {
+        this.projectNames = projectNames;
+        this.issueTypes = issueTypes;
+    }
+
+    public Set<String> getProjectNames() {
+        return projectNames;
+    }
+
+    public void setProjectNames(Set<String> projectNames) {
+        this.projectNames = projectNames;
+    }
+
+    public Set<String> getIssueTypes() {
+        return issueTypes;
+    }
+
+    public void setIssueTypes(Set<String> issueTypes) {
+        this.issueTypes = issueTypes;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+
+        result = 31 * result + projectNames.hashCode();
+        result = 31 * result + issueTypes.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (that == null || that.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final JiraConfigGrouping other = (JiraConfigGrouping) that;
+        if (!Objects.equals(this.projectNames, other.projectNames) || !Objects.equals(this.issueTypes, other.issueTypes)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/OctaneConfigGrouping.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/OctaneConfigGrouping.java
@@ -1,0 +1,73 @@
+package com.microfocus.octane.plugins.configuration.v3;
+
+import com.microfocus.octane.plugins.configuration.OctaneWorkspace;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class OctaneConfigGrouping {
+
+    private Set<OctaneWorkspace> octaneWorkspaces;
+    private String octaneUdf;
+    private Set<String> octaneEntityTypes;
+
+    public OctaneConfigGrouping() {
+    }
+
+    public OctaneConfigGrouping(Set<OctaneWorkspace> octaneWorkspaces, String octaneUdf, Set<String> octaneEntityTypes) {
+        this.octaneWorkspaces = octaneWorkspaces;
+        this.octaneUdf = octaneUdf;
+        this.octaneEntityTypes = octaneEntityTypes;
+    }
+
+    public Set<OctaneWorkspace> getOctaneWorkspaces() {
+        return octaneWorkspaces;
+    }
+
+    public void setOctaneWorkspaces(Set<OctaneWorkspace> octaneWorkspaces) {
+        this.octaneWorkspaces = octaneWorkspaces;
+    }
+
+    public String getOctaneUdf() {
+        return octaneUdf;
+    }
+
+    public void setOctaneUdf(String octaneUdf) {
+        this.octaneUdf = octaneUdf;
+    }
+
+    public Set<String> getOctaneEntityTypes() {
+        return octaneEntityTypes;
+    }
+
+    public void setOctaneEntityTypes(Set<String> octaneEntityTypes) {
+        this.octaneEntityTypes = octaneEntityTypes;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+
+        result = 31 * result + octaneWorkspaces.hashCode();
+        result = 31 * result + octaneUdf.hashCode();
+        result = 31 * result + octaneEntityTypes.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (that == null || that.getClass() != this.getClass()) {
+            return false;
+        }
+
+        final OctaneConfigGrouping other = (OctaneConfigGrouping) that;
+        if (!Objects.equals(this.octaneWorkspaces, other.octaneWorkspaces)
+                || !Objects.equals(this.octaneUdf, other.octaneUdf)
+                || !Objects.equals(this.octaneEntityTypes,other.octaneEntityTypes)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ *     Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.microfocus.octane.plugins.configuration.v3;
+
+
+import com.microfocus.octane.plugins.configuration.LocationParts;
+import com.microfocus.octane.plugins.configuration.OctaneRestManager;
+import com.microfocus.octane.plugins.rest.RestConnector;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpaceConfiguration {
+
+    private String name;
+    private String location;
+    private LocationParts locationParts;
+    private String clientId;
+    private String clientSecret;
+    private String id;
+
+    @JsonIgnore
+    private RestConnector restConnector;
+
+    public SpaceConfiguration() {
+    }
+
+    public SpaceConfiguration(String name, String location, LocationParts locationParts, String clientId, String clientSecret, String id) {
+        this.name = name;
+        this.location = location;
+        this.locationParts = locationParts;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public LocationParts getLocationParts() {
+        return locationParts;
+    }
+
+    public void setLocationParts(LocationParts locationParts) {
+        this.locationParts = locationParts;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonIgnore
+    public RestConnector getRestConnector() {
+        if (restConnector == null) {
+            restConnector = OctaneRestManager.getRestConnector(getLocationParts().getBaseUrl(), getClientId(), getClientSecret());
+        }
+        return restConnector;
+    }
+
+    public void clearRestConnector() {
+        restConnector = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpaceConfiguration that = (SpaceConfiguration) o;
+        return location.equals(that.location) && locationParts.equals(that.locationParts) && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location, locationParts, id);
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/WorkspaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/WorkspaceConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ *     Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package com.microfocus.octane.plugins.configuration.v3;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkspaceConfiguration {
+
+    private String id;
+    private String spaceConfigurationId;
+    private OctaneConfigGrouping octaneConfigGrouping;
+    private JiraConfigGrouping jiraConfigGrouping;
+
+    public WorkspaceConfiguration() {
+    }
+
+    public WorkspaceConfiguration(String id, String spaceConfigurationId, OctaneConfigGrouping octaneConfigGrouping, JiraConfigGrouping jiraConfigGrouping) {
+        this.id = id;
+        this.spaceConfigurationId = spaceConfigurationId;
+        this.octaneConfigGrouping = octaneConfigGrouping;
+        this.jiraConfigGrouping = jiraConfigGrouping;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSpaceConfigurationId() {
+        return spaceConfigurationId;
+    }
+
+    public void setSpaceConfigurationId(String spaceConfigurationId) {
+        this.spaceConfigurationId = spaceConfigurationId;
+    }
+
+    public OctaneConfigGrouping getOctaneConfigGrouping() {
+        return octaneConfigGrouping;
+    }
+
+    public void setOctaneConfigGrouping(OctaneConfigGrouping octaneConfigGrouping) {
+        this.octaneConfigGrouping = octaneConfigGrouping;
+    }
+
+    public JiraConfigGrouping getJiraConfigGrouping() {
+        return jiraConfigGrouping;
+    }
+
+    public void setJiraConfigGrouping(JiraConfigGrouping jiraConfigsGrouping) {
+        this.jiraConfigGrouping = jiraConfigsGrouping;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/upgrader/UpgraderFromV2ToV3.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/upgrader/UpgraderFromV2ToV3.java
@@ -1,0 +1,72 @@
+package com.microfocus.octane.plugins.configuration.v3.upgrader;
+
+import com.microfocus.octane.plugins.configuration.v3.*;
+import com.microfocus.octane.plugins.configuration.OctaneWorkspace;
+import com.microfocus.octane.plugins.configuration.v2.ConfigurationCollectionV2;
+import com.microfocus.octane.plugins.tools.JsonHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UpgraderFromV2ToV3 {
+
+    private static final Logger log = LoggerFactory.getLogger(UpgraderFromV2ToV3.class);
+
+    public static ConfigurationCollection upgradeConfigurationFromV2ToV3(String confStrV2) {
+        ConfigurationCollection tempConfiguration = null;
+
+        try {
+            ConfigurationCollectionV2 configurationV2 = JsonHelper.deserialize(confStrV2, ConfigurationCollectionV2.class);
+
+            if (!configurationV2.getSpaces().isEmpty()) {
+
+                List<SpaceConfiguration> spaceConfigurations = configurationV2.getSpaces().stream()
+                        .map(spaceConfigurationV2 -> new SpaceConfiguration(
+                                spaceConfigurationV2.getName(),
+                                spaceConfigurationV2.getLocation(),
+                                spaceConfigurationV2.getLocationParts(),
+                                spaceConfigurationV2.getClientId(),
+                                spaceConfigurationV2.getClientSecret(),
+                                spaceConfigurationV2.getId()))
+                        .collect(Collectors.toList());
+
+                List<WorkspaceConfiguration> workspaceConfigurations = configurationV2.getWorkspaces().stream()
+                        .map(workspaceConfigurationV2 -> new WorkspaceConfiguration(
+                                workspaceConfigurationV2.getId(),
+                                workspaceConfigurationV2.getSpaceConfigurationId(),
+                                new OctaneConfigGrouping(
+                                        new HashSet<>(List.of(
+                                                new OctaneWorkspace(
+                                                        String.valueOf(workspaceConfigurationV2.getWorkspaceId()),
+                                                        workspaceConfigurationV2.getWorkspaceName()
+                                                ))),
+                                        workspaceConfigurationV2.getOctaneUdf(),
+                                        workspaceConfigurationV2.getOctaneEntityTypes()),
+                                new JiraConfigGrouping(
+                                        workspaceConfigurationV2.getJiraProjects(),
+                                        workspaceConfigurationV2.getJiraIssueTypes()
+                                )))
+                        .collect(Collectors.toList());
+
+                tempConfiguration = new ConfigurationCollection();
+                tempConfiguration.setSpaces(spaceConfigurations);
+                tempConfiguration.setWorkspaces(workspaceConfigurations);
+
+                if (configurationV2.getProxy() != null) {
+                    tempConfiguration.setProxy(configurationV2.getProxy());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed tryConvertFromConfigurationV2: " + e.getMessage());
+        }
+
+        if (tempConfiguration == null) {
+            tempConfiguration = new ConfigurationCollection();
+        }
+
+        return tempConfiguration;
+    }
+}

--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -16,6 +16,7 @@
 package com.microfocus.octane.plugins.descriptors;
 
 import com.microfocus.octane.plugins.configuration.*;
+import com.microfocus.octane.plugins.configuration.v3.SpaceConfiguration;
 
 public class OctaneEntityTypeDescriptor {
 

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -19,8 +19,8 @@ import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.user.ApplicationUser;
 import com.microfocus.octane.plugins.configuration.ConfigurationManager;
 import com.microfocus.octane.plugins.configuration.OctaneRestManager;
-import com.microfocus.octane.plugins.configuration.SpaceConfiguration;
-import com.microfocus.octane.plugins.configuration.WorkspaceConfiguration;
+import com.microfocus.octane.plugins.configuration.v3.SpaceConfiguration;
+import com.microfocus.octane.plugins.configuration.v3.WorkspaceConfiguration;
 import com.microfocus.octane.plugins.descriptors.AggregateDescriptor;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeDescriptor;
 import com.microfocus.octane.plugins.descriptors.OctaneEntityTypeManager;
@@ -209,12 +209,12 @@ public class CoverageUiHelper {
             WorkspaceConfiguration workspaceConfig = ConfigurationManager.getInstance().getWorkspaceConfigurationById(workspaceConfigId, true).get();
             SpaceConfiguration spaceConfiguration = ConfigurationManager.getInstance().getSpaceConfigurationById(workspaceConfig.getSpaceConfigurationId(), true).get();
 
-            QueryPhrase jiraKeyCondition = new InQueryPhrase(workspaceConfig.getOctaneUdf(), Arrays.asList(issueKey, issueId.toString()));
+            QueryPhrase jiraKeyCondition = new InQueryPhrase(workspaceConfig.getOctaneConfigGrouping().getOctaneUdf(), Arrays.asList(issueKey, issueId.toString()));
             boolean found = false;
             for (AggregateDescriptor aggDescriptor : OctaneEntityTypeManager.getAggregators()) {
                 boolean isMatch = false;
                 for (OctaneEntityTypeDescriptor entityDesc : aggDescriptor.getDescriptors()) {
-                    if (workspaceConfig.getOctaneEntityTypes().contains(entityDesc.getTypeName())) {
+                    if (workspaceConfig.getOctaneConfigGrouping().getOctaneEntityTypes().contains(entityDesc.getTypeName())) {
                         isMatch = true;
                         break;
                     }
@@ -230,18 +230,18 @@ public class CoverageUiHelper {
 
                         //totalTestsCount
                         start = System.currentTimeMillis();
-                        long totalTestCount = OctaneRestManager.getTotalTestsCount(spaceConfiguration, octaneEntity, typeDescriptor, workspaceConfig.getWorkspaceId());
+                        long totalTestCount = OctaneRestManager.getTotalTestsCount(spaceConfiguration, octaneEntity, typeDescriptor, Long.parseLong(workspaceId));
                         perfMap.put("totalTestsCount", System.currentTimeMillis() - start);
 
                         //coverage
                         start = System.currentTimeMillis();
-                        List<MapBasedObject> coverageGroups = getCoverageGroups(spaceConfiguration, octaneEntity, typeDescriptor, workspaceConfig.getWorkspaceId(), aggDescriptor.isSubtyped());
+                        List<MapBasedObject> coverageGroups = getCoverageGroups(spaceConfiguration, octaneEntity, typeDescriptor, Long.parseLong(workspaceId), aggDescriptor.isSubtyped());
                         perfMap.put("coverage", System.currentTimeMillis() - start);
 
                         //fill context map
                         octaneEntity.put("url", typeDescriptor.buildEntityUrl(spaceConfiguration.getLocationParts().getBaseUrl(),
-                                spaceConfiguration.getLocationParts().getSpaceId(), workspaceConfig.getWorkspaceId(), octaneEntity.getId()));
-                        octaneEntity.put("testTabUrl", typeDescriptor.buildTestTabEntityUrl(spaceConfiguration, workspaceConfig.getWorkspaceId(),
+                                spaceConfiguration.getLocationParts().getSpaceId(), Long.parseLong(workspaceId), octaneEntity.getId()));
+                        octaneEntity.put("testTabUrl", typeDescriptor.buildTestTabEntityUrl(spaceConfiguration, Long.parseLong(workspaceId),
                                 octaneEntity.getId(), (String) octaneEntity.getFields().get("subtype")));
                         octaneEntity.put("typeAbbreviation", typeDescriptor.getTypeAbbreviation());
                         octaneEntity.put("typeColor", typeDescriptor.getTypeColor());

--- a/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanelCondition.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/TestCoverageWebPanelCondition.java
@@ -21,7 +21,7 @@ import com.atlassian.jira.project.Project;
 import com.atlassian.plugin.PluginParseException;
 import com.atlassian.plugin.web.Condition;
 import com.microfocus.octane.plugins.configuration.ConfigurationManager;
-import com.microfocus.octane.plugins.configuration.WorkspaceConfiguration;
+import com.microfocus.octane.plugins.configuration.v3.WorkspaceConfiguration;
 
 import java.util.List;
 import java.util.Map;
@@ -45,14 +45,14 @@ public class TestCoverageWebPanelCondition implements Condition {
         Project project = (Project) map.get("project");
 
         List<WorkspaceConfiguration> workspaceConfigs = ConfigurationManager.getInstance().getWorkspaceConfigurations().stream()
-                .filter(wc -> wc.getJiraProjects().contains(project.getKey()))
+                .filter(wc -> wc.getJiraConfigGrouping().getProjectNames().contains(project.getKey()))
                 .collect(Collectors.toList());
 
         if (!workspaceConfigs.isEmpty()) {
             Issue issue = (Issue) map.get("issue");
             String issueType = issue.getIssueType().getName();
 
-            return workspaceConfigs.stream().anyMatch(workspaceConfig -> workspaceConfig.getJiraIssueTypes().contains(issueType));
+            return workspaceConfigs.stream().anyMatch(workspaceConfig -> workspaceConfig.getJiraConfigGrouping().getIssueTypes().contains(issueType));
         }
 
         return false;

--- a/src/main/resources/js/jira-octane-plugin-coverage-panel.js
+++ b/src/main/resources/js/jira-octane-plugin-coverage-panel.js
@@ -41,13 +41,16 @@ function loadOctaneWorkspaces(projectKey, issueKey, issueId, issueType) {
 }
 
 function configureOctaneWorkspacesDropdown(data, projectKey, issueKey, issueId) {
-    const dropdownWorkspaces = _.sortBy(data, 'workspaceName').map(function (item) {
-        return {
-            "id": item.id, //workspaceConfigId
-            "workspaceId": item.workspaceId,
-            "text": item.workspaceName + " (" + item.spaceConfigName + ")"
-        }
-    })
+    let dropdownWorkspaces = _.sortBy(data.flatMap(wsConfig => {
+        return wsConfig.octaneWorkspaces.map(octaneWs => {
+            return {
+                "id": wsConfig.id + "-" + octaneWs.id,
+                "wsConfigId": wsConfig.id,
+                "workspaceId": octaneWs.id,
+                "text": octaneWs.name + " (" + wsConfig.spaceConfigName + ")"
+            }
+        })
+    }), 'text');
 
     AJS.$("#coverageWorkspaceSelector").auiSelect2({
         multiple: false,
@@ -61,7 +64,7 @@ function configureOctaneWorkspacesDropdown(data, projectKey, issueKey, issueId) 
         hideAllSectionsAndShowLoading();
         disableCoverageWorkspaceSelector();
 
-        await loadOctaneCoverageWidget(projectKey, issueKey, issueId, selectedWorkspace.id, selectedWorkspace.workspaceId)
+        await loadOctaneCoverageWidget(projectKey, issueKey, issueId, selectedWorkspace.wsConfigId, selectedWorkspace.workspaceId)
 
         if (dropdownWorkspaces.length !== 1) {
             enableCoverageWorkspaceSelector();

--- a/src/main/resources/templates/jira-octane-plugin-admin.vm
+++ b/src/main/resources/templates/jira-octane-plugin-admin.vm
@@ -82,7 +82,7 @@
                 <div class="description"></div>
             </div>
             <div class="field-group" id="workspace-field-group">
-                <label for="workspaceSelector">Workspace<span class="aui-icon icon-required">(required)</span></label>
+                <label for="workspaceSelector">Workspaces<span class="aui-icon icon-required">(required)</span></label>
                 <input type='hidden' name='workspaceSelector' id='workspaceSelector' class="text medium-long-field required affect-octane-entity-types"/>
                 <div class="error" id="workspaceSelectorError"></div>
                 <div class="description"></div>
@@ -93,6 +93,7 @@
                 <span id="octane-possible-fields-tooltip" class="aui-icon aui-icon-small aui-iconfont-info-circle" style="margin-left: 9px;" title=""></span>
                 <div class="error"  id="octaneUdfError"></div>
                 <div class="description">ALM Octane user-defined field for mapping Jira issues.</div>
+                <div id="octaneUdfNote" class="description hidden">Note: Please use the same user-defined field for all selected workspaces.</div>
             </div>
             <div class="field-group">
                 <label for="octaneEntityTypes">Entity types<span class="aui-icon icon-required">(required)</span></label>
@@ -120,6 +121,10 @@
         <div class="aui-dialog2-footer-actions">
             <button id="workspace-submit-button" class="aui-button aui-button-primary">Save</button>
             <button id="workspace-cancel-button" class="aui-button aui-button-link">Cancel</button>
+        </div>
+        <div id="workspaceConfigDialogError" class="aui-dialog2-footer-hint hidden">
+            <span id="workspaceConfigDialogErrorIcon" class="aui-icon aui-icon-small aui-iconfont-error" ></span>
+            <div id="workspaceConfigDialogErrorText" class="aui-iconfont-error" style="display: inline-block">This configuration is identical to one that currently exists.</div>
         </div>
     </footer>
 </section>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2105064

(if confused about some nonexisting new code in this PR, try to check the coverage one aswell - https://github.com/MicroFocus/octane-jira-coverage-plugin/pull/31)

NOTE: some classes were just moved and not refactored when tho' they are not well written

- created a new configuration (v3) which has the same spaceConfiguration with a different workspaceConfiguration
- the new workspaceConfiguration has been refactored (besides making the octane workspace a set), splitting it into 2 parts: octane part (octaneConfigGrouping) and jira part (jiraConfigGrouping)
- added a new upgrader (upgrading configuration from v2 to v3 - for reference v2 represents the old configuration which is the multi-space configuration)
- change the validation of the space configurations to be unique only by their name (instead of name + octane location)
- create a multi-select dropdown instead of single-select for workspaces inside workspace dialog
![image](https://user-images.githubusercontent.com/42770621/234512565-2e3ca74e-5980-49fe-a30b-20e24f9e4600.png)

- for the workspace configuration table, the columns 'Workspace Id' and 'Workspace Name' will be merged into a single column called 'Workspaces' which will get the data from the server in the format "_workspaceId - workspaceName_" (e.g. "1002 - default_workspace) -> the data is being passed through Outgoing objects
![image](https://user-images.githubusercontent.com/42770621/234512663-dc72f347-4246-4ef7-9ec3-1185fccecf3f.png)

- the udf and octane entity types that can be used inside workspace dialog will be the common ones between all the workspaces selected in the new dropdown
- added a validation for the workspace configurations (both front and back) so 2 identical (same octaneworkspaces, same spaceConfigId, same Udf, same Jira projects+keys) cannot be added
![image](https://user-images.githubusercontent.com/42770621/234515311-d39a906a-b85c-488e-8d14-04e3b3c4f5ac.png)

still have to do in a separate US/def: add/edit license text