### PR TITLE
defect #2158081: added tooltip for items in the dropdowns responsible for selecting octane workspaces - in coverage and workspace config dialog (hacky solution because there is no API for this)

### DIFF
--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -546,6 +546,13 @@
             $("div.select2-search input.select2-input").attr("tabindex", "0").focus();
         });
 
+        // hacky solution to show tooltip on select2 items (used because there is no API on select2 or auiselect2 for this)
+        $("#workspaceSelector").on("select2-open", function() {
+            Array.from(jQuery("#select2-drop")[0].children[0].children).forEach(function (item) {
+                item.title = item.firstChild.lastChild.textContent;
+            });
+        })
+
         AJS.$("#show-workspace-dialog").click(function (e) {
             e.preventDefault();
             showWorkspaceDialog();

--- a/src/main/resources/js/jira-octane-plugin-coverage-panel.js
+++ b/src/main/resources/js/jira-octane-plugin-coverage-panel.js
@@ -71,6 +71,13 @@ function configureOctaneWorkspacesDropdown(data, projectKey, issueKey, issueId) 
         }
     });
 
+    // hacky solution to show tooltip on select2 items (used because there is no API on select2 or auiselect2 for this)
+    AJS.$('#coverageWorkspaceSelector').on('select2-open', function () {
+        Array.from(jQuery("#select2-drop")[0].children[1].children).forEach(function (item) {
+            item.title = item.firstChild.lastChild.textContent;
+        });
+    });
+
     const selectedWorkspace = dropdownWorkspaces[0];
     jQuery("#coverageWorkspaceSelector").val(selectedWorkspace.id).trigger('change');
 }


### PR DESCRIPTION
there was no tooltip for the long named octane workspaces and there is also no API for this on the select2/auiselect2 dropdowns, so I added a hacky title (tooltip) to our items