### PR TITLE
defect #2448101: upgraded vulnerable libs;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 
-        <jira.version>9.5.1</jira.version>
-        <jira.software.application.version>9.5.1</jira.software.application.version>
+        <jira.version>9.11.1</jira.version>
+        <jira.software.application.version>9.11.1</jira.software.application.version>
         <amps.version>8.13.1</amps.version>
 
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
+        <plugin.testrunner.version>2.0.6</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -107,23 +107,67 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jta</groupId>
+                    <groupId>javax.transaction</groupId>
                     <artifactId>jta</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>wink-client</groupId>
+                    <artifactId>wink-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>lucene-extras</groupId>
+                    <artifactId>lucene-extras</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-text</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>webwork</groupId>
+                    <artifactId>webwork</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.atlassian.sal</groupId>
+                    <artifactId>sal-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
-            <groupId>jta</groupId>
+            <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
             <version>1.0.1b</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.0.0-jre</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
             <version>3.1.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001%2F1002#/team-backlog/stories](https://center.almoctane.com/ui/?p=1001%2F1002#/team-backlog/stories)

- Parent lib: upgraded jira-api from 9.5.1 to 9.11.1 version

- Included libs upgraded:  

      embedded-crowd-api from 5.0.0-m02 to 5.0.6
      velocity from 1.6.4 to 1.6.4-atlassian-7
      lucene-extras -excluded
      commons-text from 1.6 -> excluded and added 1.11.0 version
      guava from 31.0.1-jre -> excluded and added 33.0.0-jre
      protobuf-java from 3.4.0 to 3.21.9
      jackson-mapper-asl from 1.9.13 to 1.9.14
      webwork excluded
      xercesImpl from 2.12.0 to 2.12.2
      sal-api excluded
      commons-httpclient from 3.1-atlassian-2 -> excluded and added 3.1 version

- Parent lib: upgraded atlassian-plugins-osgi-testrunner from 2.0.1 to 2.0.6 version

- Included lib upgraded:

      wink-client from 1.1.3 -> excluded and added 1.4 version
