### PR TITLE
defect #2448101: fixed header manipulation and unreleased resource STAT issues;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.wink</groupId>
-                    <artifactId>wink-client</artifactId>
+                    <groupId>com.atlassian.plugins</groupId>
+                    <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.atlassian</groupId>


### PR DESCRIPTION
- fixed header manipulation issue by adding cookie CRLF validation
- put the closable object (OutputStream) inside a try-with-resource to be auto closed when the block is finished
- fixed Secure Transport issue by using TLSv1.2 instead of SSL
- excluded unnecessary 'atlassian-plugins-osgi-testrunner' lib