### PR TITLE
defect #2448101: added charsets name to solve string converting issue;

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
@@ -327,7 +327,7 @@ public class RestConnector {
                     container.write(buffer, 0, read);
                 }
 
-                ret.setResponseData(container.toString(Charsets.UTF_8));
+                ret.setResponseData(container.toString(Charsets.UTF_8.name()));
             }
 
         } catch (IOException e) {


### PR DESCRIPTION
Added .name() to Charstes.UTF in order to solve 'NoSuchMethodError' issue when running JP on machine.