### PR TITLE
defect #2571134: change path for the entity navigation to fix the case when the user is not logged in and would not get redirected correctly

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/descriptors/OctaneEntityTypeDescriptor.java
@@ -114,7 +114,7 @@ public class OctaneEntityTypeDescriptor {
     }
 
     public String buildEntityUrl(String baseUrl, long spaceId, long workspaceId, String entityId) {
-        String octaneEntityUrl = String.format("%s/ui/?p=%s/%s#/entity-navigation?entityType=%s&id=%s",
+        String octaneEntityUrl = String.format("%s/ui/entity-navigation?p=%s/%s&entityType=%s&id=%s",
                 baseUrl, spaceId, workspaceId,
                 this.getNameForNavigation(), entityId);
         return octaneEntityUrl;


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2571134

Problem: When the user was not logged in Octane, when clicking on the entity url navigation, he would not get redirected to the actual entity that he clicked on, but on the last entity that he visited before logging out

Solution: Change the entity navigation URL to the correct one