### PR TITLE
defect #2633024: change the way we get the coverage data for work items (performance reasons)

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -45,6 +45,9 @@ public class PluginConstants {
     public static String PUBLIC_API_WORKSPACE_LEVEL_SPECIFIC_ENTITY = PUBLIC_API_WORKSPACE_LEVEL_ENTITIES + "/%s";
 
     public static String WORK_ITEM = "work_item";
+    public static String WORK_ITEMS = "work_items";
+
+    public static String LAST_RUNS_FIELD = "last_runs";
 
     //octane version
     public static final String DEFAULT_BUILD = "9999";

--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -42,6 +42,9 @@ public class PluginConstants {
 
     public static String PUBLIC_API_WORKSPACE_FORMAT = PUBLIC_API_SHAREDSPACE_FORMAT + "/workspaces/%s";
     public static String PUBLIC_API_WORKSPACE_LEVEL_ENTITIES = PUBLIC_API_WORKSPACE_FORMAT + "/%s";
+    public static String PUBLIC_API_WORKSPACE_LEVEL_SPECIFIC_ENTITY = PUBLIC_API_WORKSPACE_LEVEL_ENTITIES + "/%s";
+
+    public static String WORK_ITEM = "work_item";
 
     //octane version
     public static final String DEFAULT_BUILD = "9999";

--- a/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
@@ -40,7 +40,11 @@ import com.microfocus.octane.plugins.rest.entities.groups.GroupEntityCollection;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
+
+import static com.microfocus.octane.plugins.views.CoverageUiHelper.testStatusDescriptorsByTestCoverageKey;
 
 public class OctaneEntityParser {
 
@@ -154,5 +158,21 @@ public class OctaneEntityParser {
         } catch (IOException e) {
             throw new RuntimeException("Failed to parse Core Software Delivery Platform server version:" + e.getMessage());
         }
+    }
+
+    public static Map<String, Integer> parseTestCoverageJson(JSONObject testCoverageJson) {
+        Map<String, Integer> testCoverage = new HashMap<>();
+
+        testStatusDescriptorsByTestCoverageKey.keySet().forEach(testCoverageKey -> {
+            try {
+                if (testCoverageJson.getInt(testCoverageKey) != 0) {
+                    testCoverage.put(testCoverageKey, testCoverageJson.getInt(testCoverageKey));
+                }
+            } catch (JSONException e) {
+                throw new RuntimeException("Failed to retrieve status descriptor from the test coverage field:", e);
+            }
+        });
+
+        return testCoverage;
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/views/TestStatusDescriptor.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/TestStatusDescriptor.java
@@ -35,14 +35,16 @@ public class TestStatusDescriptor {
     private String title;
     private String color;
     private String key;
+    private String testCoverageKey;
     private int order;
 
-    public TestStatusDescriptor(String logicalName, String key, String title, String color, int order) {
+    public TestStatusDescriptor(String logicalName, String key, String testCoverageKey, String title, String color, int order) {
         this.logicalName = logicalName;
         this.title = title;
         this.color = color;
         this.order = order;
         this.key = key;
+        this.testCoverageKey = testCoverageKey;
     }
 
     public String getTitle() {
@@ -63,5 +65,9 @@ public class TestStatusDescriptor {
 
     public String getKey() {
         return key;
+    }
+
+    public String getTestCoverageKey() {
+        return testCoverageKey;
     }
 }


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2633024

- for workitems, instead of retrieving the work items with this call 'runs/groups?query="((work_items_of_last_run={(id='someId')})||(work_items_of_last_run={(subtype IN 'story','defect','feature';path='somePath*')}))"&group_by=status', just get the last_runs field (which is the Test Coverage field) and take the data from there