### PR TITLE
defect #2654062: upgrade to jira 10;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
             <version>4.0.0-71ca514</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.2</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Add dependency on jira-core if you want access to JIRA implementation classes as well as the sanctioned API. -->
         <!-- This is not normally recommended, but may be required eg when migrating a plugin originally developed against JIRA 4.x -->
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 
-        <jira.version>9.11.1</jira.version>
-        <jira.software.application.version>9.11.1</jira.software.application.version>
-        <amps.version>8.13.1</amps.version>
+        <jira.version>10.3.0</jira.version>
+        <jira.software.application.version>10.3.0</jira.software.application.version>
+        <amps.version>9.0.4</amps.version>
 
         <plugin.testrunner.version>2.0.6</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
@@ -42,37 +42,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spotbugs.version>4.2.0</spotbugs.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-        <atlassian-util-concurrent.version>2.4.1</atlassian-util-concurrent.version>
         <jaxb-impl.version>2.3.0</jaxb-impl.version>
         <jaxb-core.version>2.3.0</jaxb-core.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
         <javax-activation.version>1.1</javax-activation.version>
         <FastInfoset.version>1.2.1</FastInfoset.version>
-        <jakarta.xml.bind-api.version>4.0.0-RC1</jakarta.xml.bind-api.version>
-        <jvnet.staxex.version>2.1.0-M1</jvnet.staxex.version>
-        <jakarta.activation-api.version>2.1.0-RC1</jakarta.activation-api.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.xml.bind-api.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.sun.xml.fastinfoset</groupId>
             <artifactId>FastInfoset</artifactId>
             <version>${FastInfoset.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jvnet.staxex</groupId>
-            <artifactId>stax-ex</artifactId>
-            <version>${jvnet.staxex.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <version>${jakarta.activation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -151,6 +132,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.0.0-jre</version>
@@ -195,7 +181,7 @@
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
@@ -229,14 +215,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.util.concurrent</groupId>
-            <artifactId>atlassian-util-concurrent</artifactId>
-            <version>${atlassian-util-concurrent.version}</version>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>osgi-resource-locator</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
         <!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microfocus.octane.plugins</groupId>
     <artifactId>jira-octane-quality-insight-plugin</artifactId>
-    <version>CE-24.4.1</version>
+    <version>CE-24.4.2</version>
     <organization>
         <name>Open Text</name>
         <url>https://www.opentext.com/</url>

--- a/src/main/java/com/microfocus/octane/plugins/configuration/LocationParts.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/LocationParts.java
@@ -29,7 +29,7 @@
 
 package com.microfocus.octane.plugins.configuration;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class LocationParts {
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/VersionEntity.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/VersionEntity.java
@@ -28,8 +28,8 @@
  ******************************************************************************/
 package com.microfocus.octane.plugins.configuration;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VersionEntity {

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v1/WorkspaceConfigurationV1.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v1/WorkspaceConfigurationV1.java
@@ -29,7 +29,7 @@
 
 package com.microfocus.octane.plugins.configuration.v1;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Set;
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/SpaceConfigurationV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/SpaceConfigurationV2.java
@@ -30,11 +30,11 @@
 package com.microfocus.octane.plugins.configuration.v2;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.microfocus.octane.plugins.configuration.LocationParts;
 import com.microfocus.octane.plugins.configuration.OctaneRestManager;
 import com.microfocus.octane.plugins.rest.RestConnector;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 import java.util.Objects;
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v2/WorkspaceConfigurationV2.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v2/WorkspaceConfigurationV2.java
@@ -29,7 +29,7 @@
 
 package com.microfocus.octane.plugins.configuration.v2;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Set;
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
@@ -30,11 +30,11 @@
 package com.microfocus.octane.plugins.configuration.v3;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.microfocus.octane.plugins.configuration.LocationParts;
 import com.microfocus.octane.plugins.configuration.OctaneRestManager;
 import com.microfocus.octane.plugins.rest.RestConnector;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 import java.util.Objects;
 

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/WorkspaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/WorkspaceConfiguration.java
@@ -29,7 +29,7 @@
 
 package com.microfocus.octane.plugins.configuration.v3;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkspaceConfiguration {

--- a/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/OctaneEntityParser.java
@@ -32,12 +32,12 @@ package com.microfocus.octane.plugins.rest;
 import com.atlassian.jira.util.json.JSONArray;
 import com.atlassian.jira.util.json.JSONException;
 import com.atlassian.jira.util.json.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microfocus.octane.plugins.configuration.VersionEntity;
 import com.microfocus.octane.plugins.rest.entities.OctaneEntity;
 import com.microfocus.octane.plugins.rest.entities.OctaneEntityCollection;
 import com.microfocus.octane.plugins.rest.entities.groups.GroupEntity;
 import com.microfocus.octane.plugins.rest.entities.groups.GroupEntityCollection;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
@@ -29,12 +29,11 @@
 
 package com.microfocus.octane.plugins.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.microfocus.octane.plugins.configuration.PluginConstants;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/microfocus/octane/plugins/rest/RestStatusException.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestStatusException.java
@@ -30,7 +30,8 @@
 
 package com.microfocus.octane.plugins.rest;
 
-import com.google.gson.Gson;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Map;
 
@@ -51,7 +52,8 @@ public class RestStatusException extends RuntimeException {
 
         try {
             if (response.getResponseData().startsWith("{")) {
-                Map statusData = new Gson().fromJson(response.getResponseData(), Map.class);
+                ObjectMapper objectMapper = new ObjectMapper();
+                Map<String, Object> statusData = objectMapper.readValue(response.getResponseData(), new TypeReference<Map<String, Object>>() {});
                 error_code = (String) statusData.get("error_code");
                 description = (String) statusData.get("description");
             }

--- a/src/main/java/com/microfocus/octane/plugins/rest/entities/MapBasedObject.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/entities/MapBasedObject.java
@@ -29,8 +29,8 @@
 
 package com.microfocus.octane.plugins.rest.entities;
 
-import org.codehaus.jackson.annotate.JsonAnyGetter;
-import org.codehaus.jackson.annotate.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;

--- a/src/main/java/com/microfocus/octane/plugins/tools/JsonHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/tools/JsonHelper.java
@@ -29,7 +29,7 @@
 
 package com.microfocus.octane.plugins.tools;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageResource.java
@@ -33,9 +33,9 @@ import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microfocus.octane.plugins.configuration.ConfigurationManager;
 import com.microfocus.octane.plugins.configuration.v3.WorkspaceConfiguration;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
+++ b/src/main/java/com/microfocus/octane/plugins/views/CoverageUiHelper.java
@@ -31,7 +31,6 @@ package com.microfocus.octane.plugins.views;
 
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.user.ApplicationUser;
-import com.atlassian.util.concurrent.NotNull;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -56,6 +55,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotNull;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;


### PR DESCRIPTION
Link defect: [https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2654062](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2654062)

- Upgraded jira version to 10.3.0
- Upgraded amps version to 9.0.4
- Added 'commons-lang' version 2.4 required after upgraded jira
- Added 'osgi-resource-locator' version 2.4.0 with scope provided;  required after the Jira upgrade
- Added scope proivided to 'atlassian-spring-scanner-annotation', as it is provided by Jira
- Replaced all the imports from 'codehaus.jackson' to 'fasterxml.jackson', as codehaus is deprecated in jira 10
- Removed banned dependencies: 
          -com.atlassian.util.concurrent:atlassian-util-concurrent:jar:2.4.1
          -com.google.code.gson:gson:jar:2.8.9
          -jakarta.activation:jakarta.activation-api:jar:2.1.0-RC1   