### PR TITLE
defect #2654062: fix upgrade compatibility with both jira 10 and jira 9;

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.18.2</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Add dependency on jira-core if you want access to JIRA implementation classes as well as the sanctioned API. -->
         <!-- This is not normally recommended, but may be required eg when migrating a plugin originally developed against JIRA 4.x -->
@@ -188,12 +187,6 @@
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -224,7 +217,6 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>osgi-resource-locator</artifactId>
             <version>2.4.0</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
         <!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->
@@ -312,6 +304,13 @@
                             <version>${jira.software.application.version}</version>
                         </application>
                     </applications>
+                    <banningExcludes>
+                        <!-- Exclude Jackson dependencies from banned list as they are intentionally bundled with the plugin
+                        for compatibility with Jira 9. -->
+                        <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                        <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                        <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                    </banningExcludes>
                     <!-- Uncomment to install TestKit backdoor in JIRA. -->
                     <!--
                     <pluginArtifacts>
@@ -400,6 +399,22 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>6.0.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            com.fasterxml.jackson.core.*;resolution:=optional,
+                            com.fasterxml.jackson.databind.*;resolution:=optional,
+                            com.fasterxml.jackson.annotations.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microfocus.octane.plugins</groupId>
     <artifactId>jira-octane-quality-insight-plugin</artifactId>
-    <version>CE-24.4.2</version>
+    <version>CE-25.1</version>
     <organization>
         <name>Open Text</name>
         <url>https://www.opentext.com/</url>

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
+       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
Link defect: [https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2654062](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2654062)

For maintaining compatibility between the plugin for Jira 9 and Jira 10:

- updated the atlassian-scanner namespaces in `plugin-context.xml `as per the latest guidance: [https://bitbucket.org/atlassian/atlassian-spring-scanner/src/atlassian-spring-scanner-parent-3.0.0/](https://bitbucket.org/atlassian/atlassian-spring-scanner/src/atlassian-spring-scanner-parent-3.0.0/)

- removed provided scope from jackson-databind dependency to ensure it is bundled with the plugin

- configured all com.fasterxml.* package imports to be optional, allowing compatibility with Jira's platform-provided libraries

- excluded Jackson dependencies from the banned list as they are intentionally bundled with the plugin for compatibility with Jira 9, while Jira 10 or later will use its platform-provided Jackson libraries, as controlled by the optional OSGi imports.

Guidance on using `com.fasterxml.jackson` with both on jira 9 and jira 10: [https://community.developer.atlassian.com/t/preparing-for-jira-software-10-0-and-jira-service-management-6-0-multiple-eaps-coming-your-way/76688/301](https://community.developer.atlassian.com/t/preparing-for-jira-software-10-0-and-jira-service-management-6-0-multiple-eaps-coming-your-way/76688/301)
