### PR TITLE
tech: encode the query params - the plugin randomly stopped working because the Octane would return status 400 on some calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microfocus.octane.plugins</groupId>
     <artifactId>jira-octane-quality-insight-plugin</artifactId>
-    <version>CE-25.2</version>
+    <version>CE-25.3</version>
     <organization>
         <name>Open Text</name>
         <url>https://www.opentext.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 
-        <jira.version>10.3.0</jira.version>
-        <jira.software.application.version>10.3.0</jira.software.application.version>
-        <amps.version>9.0.4</amps.version>
+        <jira.version>10.6.1</jira.version>
+        <jira.software.application.version>10.6.1</jira.software.application.version>
+        <amps.version>9.3.4</amps.version>
 
         <plugin.testrunner.version>2.0.6</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -11,6 +11,11 @@
     <param name="atlassian-data-center-compatible">true</param>
     <param name="plugin-type">both</param>
   </plugin-info>
+
+  <velocity-allowlist key="${project.name}-velocity-allowlist">
+    <method>com.microfocus.octane.plugins.rest.entities.MapBasedObject#get(java.lang.String)</method>
+  </velocity-allowlist>
+
   <!-- add our i18n resource -->
   <resource type="i18n" name="i18n" location="jira-octane-plugin"/>
 


### PR DESCRIPTION
 encode the query params - the plugin randomly stopped working because the Octane would return status 400 on some calls