### PR TITLE
user story #3011011: implement federated login (oidc)

### DIFF
--- a/src/main/java/com/microfocus/octane/plugins/admin/SpaceConfigurationOutgoing.java
+++ b/src/main/java/com/microfocus/octane/plugins/admin/SpaceConfigurationOutgoing.java
@@ -53,6 +53,18 @@ public class SpaceConfigurationOutgoing {
     @XmlElement(name = "name")
     private String name;
 
+    @XmlElement(name = "oidcEnabled")
+    private Boolean oidcEnabled;
+
+    @XmlElement(name = "discoveryUrl")
+    private String discoveryUrl;
+
+    @XmlElement(name = "oidcClientId")
+    private String oidcClientId;
+
+    @XmlElement(name = "oidcClientSecret")
+    private String oidcClientSecret;
+
     public String getId() {
         return id;
     }
@@ -95,6 +107,46 @@ public class SpaceConfigurationOutgoing {
 
     public SpaceConfigurationOutgoing setName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public Boolean getOidcEnabled() {
+        return oidcEnabled;
+    }
+
+    public SpaceConfigurationOutgoing setOidcEnabled(Boolean oidcEnabled) {
+        this.oidcEnabled = oidcEnabled;
+
+        return this;
+    }
+
+    public String getDiscoveryUrl() {
+        return discoveryUrl;
+    }
+
+    public SpaceConfigurationOutgoing setDiscoveryUrl(String discoveryUrl) {
+        this.discoveryUrl = discoveryUrl;
+
+        return this;
+    }
+
+    public String getOidcClientId() {
+        return oidcClientId;
+    }
+
+    public SpaceConfigurationOutgoing setOidcClientId(String oidcClientId) {
+        this.oidcClientId = oidcClientId;
+
+        return this;
+    }
+
+    public String getOidcClientSecret() {
+        return oidcClientSecret;
+    }
+
+    public SpaceConfigurationOutgoing setOidcClientSecret(String oidcClientSecret) {
+        this.oidcClientSecret = oidcClientSecret;
+
         return this;
     }
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -241,7 +241,7 @@ public class ConfigurationUtil {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Test connection failed: " + e.getMessage()); //rethrow IllegalArgumentExceptions, so it can catch the Runtime ones
         } catch (RuntimeException e) {
-            throw new IllegalArgumentException("Test connection failed: Error occurred while trying to test the connection. Please check the host.");
+            throw new IllegalArgumentException("Test connection failed: Error occurred while trying to test the connection. Please check the host." + e.getMessage());
         } catch (Exception e) {
             throw new IllegalArgumentException("Test connection failed: " + e.getMessage());
         }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -250,6 +250,8 @@ public class ConfigurationUtil {
     public static String parseExceptionMessage(RestStatusException e, SpaceConfiguration spaceConfig) {
         if (e.getStatus() == 404 && e.getMessage().contains("SharedSpaceNotFoundException")) {
             return String.format("Space id '%d' does not exist", spaceConfig.getLocationParts().getSpaceId());
+        } else if (e.getStatus() == 401 && e.getMessage().contains("Not Authenticated")) {
+            return "Authentication failed: Please check client ID and client secret";
         } else {
             return "Test connection failed: " + e.getMessage();
         }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/ConfigurationUtil.java
@@ -137,6 +137,15 @@ public class ConfigurationUtil {
             throw new IllegalArgumentException("Client secret is required");
         }
 
+        if (sco.getOidcEnabled()) {
+            if (StringUtils.isEmpty(sco.getDiscoveryUrl())) {
+                throw new IllegalArgumentException("OIDC Discovery URL is required when OIDC is enabled");
+            }
+            if (StringUtils.isEmpty(sco.getOidcClientId()) || StringUtils.isEmpty(sco.getOidcClientSecret())) {
+                throw new IllegalArgumentException("Octane OIDC client credentials are required when OIDC is enabled");
+            }
+        }
+
         LocationParts locationParts = null;
         try {
             locationParts = parseUiLocation(sco.getLocation().trim());
@@ -146,6 +155,7 @@ public class ConfigurationUtil {
         }
 
         String clientSecret = sco.getClientSecret();
+        String oidcClientSecret = sco.getOidcClientSecret();
         if (isNew) {
             //validate id is missing
             if (StringUtils.isNotEmpty(sco.getId())) {
@@ -163,28 +173,39 @@ public class ConfigurationUtil {
             if (PluginConstants.PASSWORD_REPLACE.equals(clientSecret) && !isNew) {
                 clientSecret = opt.get().getClientSecret();
             }
+
+            if (sco.getOidcEnabled()) {
+                if (PluginConstants.PASSWORD_REPLACE.equals(oidcClientSecret)) {
+                    oidcClientSecret = opt.get().getOidcClientSecret();
+                }
+            }
         }
 
         //convert
-        SpaceConfiguration sc = new SpaceConfiguration(
+        return new SpaceConfiguration(
                 sco.getName().trim(),
                 sco.getLocation().trim(),
                 locationParts,
                 sco.getClientId().trim(),
                 clientSecret,
-                sco.getId());
-
-        return sc;
+                sco.getId(),
+                sco.getOidcEnabled(),
+                sco.getDiscoveryUrl(),
+                sco.getOidcClientId(),
+                oidcClientSecret);
     }
 
     public static SpaceConfigurationOutgoing convertToOutgoing(SpaceConfiguration sc) {
-        SpaceConfigurationOutgoing sco = new SpaceConfigurationOutgoing()
+        return new SpaceConfigurationOutgoing()
                 .setId(sc.getId())
                 .setName(sc.getName())
                 .setLocation(sc.getLocation())
                 .setClientSecret(PluginConstants.PASSWORD_REPLACE)
-                .setClientId(sc.getClientId());
-        return sco;
+                .setClientId(sc.getClientId())
+                .setDiscoveryUrl(sc.getDiscoveryUrl())
+                .setOidcClientId(sc.getOidcClientId())
+                .setOidcClientSecret(PluginConstants.PASSWORD_REPLACE)
+                .setOidcEnabled(sc.getOidcEnabled());
     }
 
     public static void doSpaceConfigurationUniquenessValidation(SpaceConfiguration spaceConfiguration, boolean isConnectionTested) {

--- a/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/PluginConstants.java
@@ -54,4 +54,20 @@ public class PluginConstants {
     public static final String SEPARATOR = ".";
     public static final String FUGEES_VERSION = "15.1.90";
     public static final String GUNSNROSES_PUSH2 = "16.0.16";
+
+    // OIDC Constants
+    public static final String OIDC_GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+    public static final String OIDC_GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
+    public static final String OIDC_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+    public static final String OIDC_CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+    public static final String OIDC_OCTANE_TOKEN_PATH = "/osp/a/au/auth/oauth2/token";
+    public static final String OIDC_DISCOVERY_TOKEN_ENDPOINT = "token_endpoint";
+    public static final String OIDC_ACCESS_TOKEN_FIELD = "access_token";
+    public static final String OIDC_COOKIE_NAME = "access_token";
+
+    public static final String OIDC_PARAM_GRANT_TYPE = "grant_type";
+    public static final String OIDC_PARAM_CLIENT_ID = "client_id";
+    public static final String OIDC_PARAM_CLIENT_SECRET = "client_secret";
+    public static final String OIDC_PARAM_SUBJECT_TOKEN_TYPE = "subject_token_type";
+    public static final String OIDC_PARAM_SUBJECT_TOKEN = "subject_token";
 }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/SpaceConfiguration.java
@@ -33,8 +33,8 @@ package com.microfocus.octane.plugins.configuration.v3;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.microfocus.octane.plugins.configuration.LocationParts;
-import com.microfocus.octane.plugins.configuration.OctaneRestManager;
 import com.microfocus.octane.plugins.rest.RestConnector;
+import com.microfocus.octane.plugins.configuration.OctaneRestManager;
 
 import java.util.Objects;
 
@@ -47,6 +47,10 @@ public class SpaceConfiguration {
     private String clientId;
     private String clientSecret;
     private String id;
+    private Boolean oidcEnabled;
+    private String discoveryUrl;
+    private String oidcClientId;
+    private String oidcClientSecret;
 
     @JsonIgnore
     private RestConnector restConnector;
@@ -61,6 +65,19 @@ public class SpaceConfiguration {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.id = id;
+    }
+
+    public SpaceConfiguration(String name, String location, LocationParts locationParts, String clientId, String clientSecret, String id, Boolean oidcEnabled, String discoveryUrl, String oidcClientId, String oidcClientSecret) {
+        this.name = name;
+        this.location = location;
+        this.locationParts = locationParts;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.id = id;
+        this.oidcEnabled = oidcEnabled;
+        this.discoveryUrl = discoveryUrl;
+        this.oidcClientId = oidcClientId;
+        this.oidcClientSecret = oidcClientSecret;
     }
 
     public String getName() {
@@ -111,10 +128,51 @@ public class SpaceConfiguration {
         this.id = id;
     }
 
+    public Boolean getOidcEnabled() {
+        return oidcEnabled;
+    }
+
+    public void setOidcEnabled(Boolean oidcEnabled) {
+        this.oidcEnabled = oidcEnabled;
+    }
+
+    public String getDiscoveryUrl() {
+        return discoveryUrl;
+    }
+
+    public void setDiscoveryUrl(String discoveryUrl) {
+        this.discoveryUrl = discoveryUrl;
+    }
+
+    public String getOidcClientId() {
+        return oidcClientId;
+    }
+
+    public void setOidcClientId(String oidcClientId) {
+        this.oidcClientId = oidcClientId;
+    }
+
+    public String getOidcClientSecret() {
+        return oidcClientSecret;
+    }
+
+    public void setOidcClientSecret(String oidcClientSecret) {
+        this.oidcClientSecret = oidcClientSecret;
+    }
+
     @JsonIgnore
     public RestConnector getRestConnector() {
         if (restConnector == null) {
-            restConnector = OctaneRestManager.getRestConnector(getLocationParts().getBaseUrl(), getClientId(), getClientSecret());
+            if (getOidcEnabled()) {
+                RestConnector rc = new RestConnector();
+                rc.setBaseUrl(getLocationParts().getBaseUrl());
+                rc.setCredentials(getClientId(), getClientSecret());
+                rc.setOidcConfiguration(getDiscoveryUrl(), getOidcClientId(), getOidcClientSecret(), getOidcEnabled());
+
+                return rc;
+            } else {
+                return OctaneRestManager.getRestConnector(getLocationParts().getBaseUrl(), getClientId(), getClientSecret());
+            }
         }
         return restConnector;
     }

--- a/src/main/java/com/microfocus/octane/plugins/configuration/v3/upgrader/UpgraderFromV2ToV3.java
+++ b/src/main/java/com/microfocus/octane/plugins/configuration/v3/upgrader/UpgraderFromV2ToV3.java
@@ -35,6 +35,7 @@ import com.microfocus.octane.plugins.tools.JsonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,7 +67,7 @@ public class UpgraderFromV2ToV3 {
                                 workspaceConfigurationV2.getId(),
                                 workspaceConfigurationV2.getSpaceConfigurationId(),
                                 new OctaneConfigGrouping(
-                                        new HashSet<>(List.of(
+                                        new HashSet<>(Collections.singletonList(
                                                 new OctaneWorkspace(
                                                         String.valueOf(workspaceConfigurationV2.getWorkspaceId()),
                                                         workspaceConfigurationV2.getWorkspaceName()

--- a/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
@@ -70,6 +70,7 @@ public class RestConnector {
     private ProxyConfiguration proxyConfiguration;
     private SSLContext sslContext;
     private static final Logger log = LoggerFactory.getLogger(RestConnector.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private boolean oidcEnabled;
     private String discoveryUrl;
@@ -79,7 +80,6 @@ public class RestConnector {
     public boolean login() {
         boolean ret = false;
         clearAll();
-        ObjectMapper mapper = new ObjectMapper();
         String jsonString = null;
         HashMap<String, String> authData = new HashMap<>();
         authData.put("user", user);
@@ -465,7 +465,6 @@ public class RestConnector {
 
     private String getTokenEndpointFromDiscovery() throws IOException {
         String discoveryJson = httpGetAbsolute(discoveryUrl);
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(discoveryJson);
         String tokenEndpoint = node.path(OIDC_DISCOVERY_TOKEN_ENDPOINT).asText();
 
@@ -501,7 +500,6 @@ public class RestConnector {
     }
 
     private String extractAccessToken(String jsonResponse, String errorMessage) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(jsonResponse);
         String accessToken = node.path(OIDC_ACCESS_TOKEN_FIELD).asText();
 

--- a/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
@@ -242,15 +242,18 @@ public class RestConnector {
                             refreshAccessToken();
                             retryResult = true;
                             String msg = String.format("Received status %s. OIDC token refresh succeeded.", e.getResponse().getStatusCode());
-                            log.warn(msg);
+
+                            log.info(msg);
                         } else {
                             retryResult = login();
                             String msg = String.format("Received status %s. Relogin succeeded.", e.getResponse().getStatusCode());
-                            log.warn(msg);
+
+                            log.info(msg);
                         }
-                    } catch (Exception ex) {
+                    } catch (IOException ex) {
                         String msg = String.format("Received status %s. Refresh/login failed %s", e.getResponse().getStatusCode(), ex.getMessage());
-                        log.warn(msg);
+
+                        log.error(msg);
                     }
 
                     if (retryResult) {

--- a/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
+++ b/src/main/java/com/microfocus/octane/plugins/rest/RestConnector.java
@@ -29,6 +29,7 @@
 
 package com.microfocus.octane.plugins.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.microfocus.octane.plugins.configuration.PluginConstants;
@@ -38,11 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.*;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -52,6 +51,8 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.Map.Entry;
 
+import static com.microfocus.octane.plugins.configuration.PluginConstants.*;
+
 
 public class RestConnector {
 
@@ -59,6 +60,7 @@ public class RestConnector {
     public final static String HEADER_APPLICATION_JSON = "application/json";
     public final static String HEADER_APPLICATION_XML = "application/xml";
     public final static String HEADER_CONTENT_TYPE = "Content-Type";
+    public final static String HEADER_AUTHORIZATION = "Authorization";
 
     protected Map<String, String> cookies = new HashMap<>();
 
@@ -68,6 +70,11 @@ public class RestConnector {
     private ProxyConfiguration proxyConfiguration;
     private SSLContext sslContext;
     private static final Logger log = LoggerFactory.getLogger(RestConnector.class);
+
+    private boolean oidcEnabled;
+    private String discoveryUrl;
+    private String oidcClientId;
+    private String oidcClientSecret;
 
     public boolean login() {
         boolean ret = false;
@@ -229,17 +236,24 @@ public class RestConnector {
             if ((e.getResponse().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) ||
                     (e.getResponse().getStatusCode() == 0 && e.getResponse().getResponseData().equals("Error writing to server"))) {
                 if (!relogin) {
-                    boolean reloginResult = false;
+                    boolean retryResult = false;
                     try {
-                        reloginResult = login();
-                        String msg = String.format("Received status %s. Relogin succeeded.", e.getResponse().getStatusCode());
-                        log.warn(msg);
+                        if (oidcEnabled) {
+                            refreshAccessToken();
+                            retryResult = true;
+                            String msg = String.format("Received status %s. OIDC token refresh succeeded.", e.getResponse().getStatusCode());
+                            log.warn(msg);
+                        } else {
+                            retryResult = login();
+                            String msg = String.format("Received status %s. Relogin succeeded.", e.getResponse().getStatusCode());
+                            log.warn(msg);
+                        }
                     } catch (Exception ex) {
-                        String msg = String.format("Received status %s. Relogin failed %s", e.getResponse().getStatusCode(), ex.getMessage());
+                        String msg = String.format("Received status %s. Refresh/login failed %s", e.getResponse().getStatusCode(), ex.getMessage());
                         log.warn(msg);
                     }
 
-                    if (reloginResult) {
+                    if (retryResult) {
                         return doHttp(type, url, queryParams, data, headers, true);
                     }
                 }
@@ -420,6 +434,188 @@ public class RestConnector {
     public void setCredentials(String user, String password) {
         this.user = user;
         this.password = password;
+    }
+
+    public void setAccessTokenCookie(String accessToken) {
+        if (StringUtils.isNotEmpty(accessToken)) {
+            cookies.put(OIDC_COOKIE_NAME, accessToken);
+        }
+    }
+
+    public void setOidcConfiguration(String discoveryUrl, String oidcClientId, String oidcClientSecret, Boolean oidcEnabled) {
+        this.discoveryUrl = discoveryUrl;
+        this.oidcClientId = oidcClientId;
+        this.oidcClientSecret = oidcClientSecret;
+        this.oidcEnabled = oidcEnabled;
+    }
+
+    private void refreshAccessToken() throws IOException {
+        if (!oidcEnabled) {
+            throw new IllegalStateException("OIDC not configured");
+        }
+
+        String tokenEndpoint = getTokenEndpointFromDiscovery();
+        String idpAccessToken = obtainIdpAccessToken(tokenEndpoint);
+        String octaneAccessToken = exchangeOctaneToken(idpAccessToken);
+        setAccessTokenCookie(octaneAccessToken);
+    }
+
+    private String getTokenEndpointFromDiscovery() throws IOException {
+        String discoveryJson = httpGetAbsolute(discoveryUrl);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(discoveryJson);
+        String tokenEndpoint = node.path(OIDC_DISCOVERY_TOKEN_ENDPOINT).asText();
+
+        if (StringUtils.isEmpty(tokenEndpoint)) {
+            throw new IllegalArgumentException("token_endpoint missing in discovery document");
+        }
+
+        return tokenEndpoint;
+    }
+
+    private String obtainIdpAccessToken(String tokenEndpoint) throws IOException {
+        Map<String, String> form = new HashMap<>();
+        form.put(OIDC_PARAM_GRANT_TYPE, OIDC_GRANT_TYPE_CLIENT_CREDENTIALS);
+        form.put(OIDC_PARAM_CLIENT_ID, user);
+        form.put(OIDC_PARAM_CLIENT_SECRET, password);
+
+        String tokenResponse = httpPostFormAbsolute(tokenEndpoint, form);
+
+        return extractAccessToken(tokenResponse, "IDP did not return access_token");
+    }
+
+    private String exchangeOctaneToken(String idpAccessToken) throws IOException {
+        String url = baseUrl + OIDC_OCTANE_TOKEN_PATH;
+
+        Map<String, String> form = new HashMap<>();
+        form.put(OIDC_PARAM_GRANT_TYPE, OIDC_GRANT_TYPE_TOKEN_EXCHANGE);
+        form.put(OIDC_PARAM_SUBJECT_TOKEN_TYPE, OIDC_SUBJECT_TOKEN_TYPE);
+        form.put(OIDC_PARAM_SUBJECT_TOKEN, idpAccessToken);
+
+        String response = httpPostFormAbsolute(url, form, oidcClientId, oidcClientSecret);
+
+        return extractAccessToken(response, "Octane did not return access_token");
+    }
+
+    private String extractAccessToken(String jsonResponse, String errorMessage) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(jsonResponse);
+        String accessToken = node.path(OIDC_ACCESS_TOKEN_FIELD).asText();
+
+        if (StringUtils.isEmpty(accessToken)) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+        return accessToken;
+    }
+
+    private String httpGetAbsolute(String url) throws IOException {
+        HttpURLConnection con = openConnectionForAbsoluteUrl(url, "GET");
+        con.setRequestProperty(HEADER_ACCEPT, HEADER_APPLICATION_JSON);
+
+        return readResponse(con, url);
+    }
+
+    private String httpPostFormAbsolute(String url, Map<String, String> form) throws IOException {
+        return httpPostFormAbsolute(url, form, null, null);
+    }
+
+    private String httpPostFormAbsolute(String url, Map<String, String> form, String clientId, String clientSecret) throws IOException {
+        HttpURLConnection con = openConnectionForAbsoluteUrl(url, "POST");
+        con.setDoOutput(true);
+        con.setRequestProperty(HEADER_CONTENT_TYPE, OIDC_CONTENT_TYPE_FORM);
+
+        if (clientId != null && clientSecret != null) {
+            String basicAuth = Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes(Charsets.UTF_8));
+            con.setRequestProperty(HEADER_AUTHORIZATION, "Basic " + basicAuth);
+        }
+
+        writeFormBody(con, form);
+
+        return readResponse(con, url);
+    }
+
+    private HttpURLConnection openConnectionForAbsoluteUrl(String urlString, String method) throws IOException {
+        URL urlObj = new URL(urlString);
+        HttpURLConnection con;
+
+        if (proxyConfiguration == null) {
+            con = (HttpURLConnection) urlObj.openConnection();
+        } else {
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyConfiguration.getHost(), proxyConfiguration.getPort()));
+            con = (HttpURLConnection) urlObj.openConnection(proxy);
+
+            if (StringUtils.isNotEmpty(proxyConfiguration.getUsername()) && StringUtils.isNotEmpty(proxyConfiguration.getPassword())) {
+                Authenticator authenticator = new Authenticator() {
+                    public PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(proxyConfiguration.getUsername(), proxyConfiguration.getPassword().toCharArray());
+                    }
+                };
+
+                Authenticator.setDefault(authenticator);
+            }
+        }
+
+        if (con instanceof HttpsURLConnection) {
+            setSSLSocketFactory((HttpsURLConnection) con);
+        }
+        con.setRequestMethod(method);
+
+        return con;
+    }
+
+    private String buildFormBody(Map<String, String> form) {
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<String, String> entry : form.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append('&');
+            }
+
+            try {
+                sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name()))
+                        .append('=')
+                        .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name()));
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalArgumentException("Failed to encode params.", e);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private void writeFormBody(HttpURLConnection con, Map<String, String> form) throws IOException {
+        String body = buildFormBody(form);
+
+        try (OutputStream os = con.getOutputStream()) {
+            os.write(body.getBytes(Charsets.UTF_8));
+        }
+    }
+
+    private String readResponse(HttpURLConnection con, String url) throws IOException {
+        int responseCode = con.getResponseCode();
+
+        try (InputStream is = (responseCode < HttpURLConnection.HTTP_BAD_REQUEST) ? con.getInputStream() : con.getErrorStream()) {
+            String response = (is != null) ? readStreamToString(is) : "";
+
+            if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
+                throw new IllegalArgumentException("HTTP " + responseCode + " calling " + url + ": " + response);
+            }
+
+            return response;
+        }
+    }
+
+    private String readStreamToString(InputStream is) throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+
+        while ((length = is.read(buffer)) != -1) {
+            result.write(buffer, 0, length);
+        }
+
+        return result.toString(StandardCharsets.UTF_8.name());
     }
 
     private void setSSLSocketFactory(HttpsURLConnection httpsURLConnection) {

--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -287,7 +287,11 @@
             name: $("#name").attr("value").trim(),
             location: $("#location").attr("value").trim(),
             clientId: $("#clientId").attr("value").trim(),
-            clientSecret: $("#clientSecret").attr("value")
+            clientSecret: $("#clientSecret").attr("value"),
+            oidcEnabled: $("#oidcEnabled").is(":checked"),
+            discoveryUrl: $("#discoveryUrl").attr("value").trim(),
+            oidcClientId: $("#oidcClientId").attr("value").trim(),
+            oidcClientSecret: $("#oidcClientSecret").attr("value")
         };
 
         var isEditMode = !!octanePluginContext.spaceCurrentRow;
@@ -343,7 +347,11 @@
             name: rowModel.name,
             location: rowModel.location,
             clientId: rowModel.clientId,
-            clientSecret: rowModel.clientSecret
+            clientSecret: rowModel.clientSecret,
+            oidcEnabled: $("#oidcEnabled").is(":checked"),
+            discoveryUrl: $("#discoveryUrl").attr("value").trim(),
+            oidcClientId: $("#oidcClientId").attr("value").trim(),
+            oidcClientSecret: $("#oidcClientSecret").attr("value")
         };
 
         //send
@@ -418,7 +426,11 @@
                 name: $("#name").attr("value").trim(),
                 location: $("#location").attr("value").trim(),
                 clientId: $("#clientId").attr("value").trim(),
-                clientSecret: $("#clientSecret").attr("value")
+                clientSecret: $("#clientSecret").attr("value"),
+                oidcEnabled: $("#oidcEnabled").is(":checked"),
+                discoveryUrl: $("#discoveryUrl").attr("value").trim(),
+                oidcClientId: $("#oidcClientId").attr("value").trim(),
+                oidcClientSecret: $("#oidcClientSecret").attr("value")
             };
 
             var url = octanePluginContext.spaceTable.options.resources.all;
@@ -444,6 +456,9 @@
                     rowModel.location = result.location;
                     rowModel.clientId = result.clientId;
                     rowModel.clientSecret = result.clientSecret;
+                    rowModel.discoveryUrl = result.discoveryUrl;
+                    rowModel.oidcClientId = result.oidcClientId;
+                    rowModel.oidcClientSecret = result.oidcClientSecret;
                     octanePluginContext.spaceCurrentRow.render();
                     reloadTable(octanePluginContext.workspaceTable);
                 } else {//new mode
@@ -809,6 +824,10 @@
             $("#location").val(model.location);
             $("#clientId").val(model.clientId);
             $("#clientSecret").val(model.clientSecret);
+            $('#oidcEnabled').prop('checked', !!model.oidcEnabled);
+            $("#discoveryUrl").val(model.discoveryUrl);
+            $("#oidcClientId").val(model.oidcClientId);
+            $("#oidcClientSecret").val(model.oidcClientSecret);
 
             $('#space-dialog-title').text("Edit");//set dialog title
         } else {//new item
@@ -817,11 +836,16 @@
             $("#clientId").val("");
             $("#clientSecret").val("");
 
-
             $('#space-dialog-title').text("Create");//set dialog title
+            $('#oidcEnabled').prop('checked', false);
         }
 
         AJS.dialog2("#space-dialog").show();
+        toggleOidcSection($('#oidcEnabled').is(':checked'));
+
+        $('#oidcEnabled').off('change').on('change', function(){
+            toggleOidcSection($('#oidcEnabled').is(':checked'));
+        });
     }
 
     var spaceErrorFlags = [];
@@ -979,6 +1003,33 @@
         el.removeClass(iconOkClass);
         el.addClass(iconFailedClass);
         el.attr("title", msg);
+    }
+
+    function toggleOidcSection(enabled) {
+        var discoveryGroup = $('#discoveryUrl').closest('.field-group');
+        var oidcClientIdGroup = $('#oidcClientId').closest('.field-group');
+        var oidcClientSecretGroup = $('#oidcClientSecret').closest('.field-group');
+
+        hideElement(discoveryGroup, !enabled);
+        hideElement(oidcClientIdGroup, !enabled);
+        hideElement(oidcClientSecretGroup, !enabled);
+
+        var $discovery = $('#discoveryUrl');
+        var $oidcId = $('#oidcClientId');
+        var $oidcSecret = $('#oidcClientSecret');
+        if (enabled) {
+            $discovery.addClass('required');
+            $oidcId.addClass('required');
+            $oidcSecret.addClass('required');
+        } else {
+            $discovery.removeClass('required');
+            $oidcId.removeClass('required');
+            $oidcSecret.removeClass('required');
+
+            $('#discoveryUrlError').text('');
+            $('#oidcClientIdError').text('');
+            $('#oidcClientSecretError').text('');
+        }
     }
 
 })(AJS.$ || jQuery);

--- a/src/main/resources/js/jira-octane-plugin-admin.js
+++ b/src/main/resources/js/jira-octane-plugin-admin.js
@@ -348,10 +348,10 @@
             location: rowModel.location,
             clientId: rowModel.clientId,
             clientSecret: rowModel.clientSecret,
-            oidcEnabled: $("#oidcEnabled").is(":checked"),
-            discoveryUrl: $("#discoveryUrl").attr("value").trim(),
-            oidcClientId: $("#oidcClientId").attr("value").trim(),
-            oidcClientSecret: $("#oidcClientSecret").attr("value")
+            oidcEnabled: rowModel.oidcEnabled,
+            discoveryUrl: rowModel.discoveryUrl,
+            oidcClientId: rowModel.oidcClientId,
+            oidcClientSecret: rowModel.oidcClientSecret
         };
 
         //send

--- a/src/main/resources/templates/jira-octane-plugin-admin.vm
+++ b/src/main/resources/templates/jira-octane-plugin-admin.vm
@@ -52,6 +52,29 @@
                 <div class="description">Client secret used for logging into the Core Software Delivery Platform server</div>
             </div>
             <div class="field-group">
+                <label for="oidcEnabled">Enable OIDC (OAuth2)</label>
+                <input type="checkbox" id="oidcEnabled" name="oidcEnabled" class="checkbox">
+                <div class="description">When enabled, the plugin authenticates using OIDC (OAuth 2.0) and token exchange.</div>
+            </div>
+            <div class="field-group">
+                <label for="discoveryUrl">OIDC Discovery URL<span class="aui-icon icon-required"></span></label>
+                <input type="text" id="discoveryUrl" name="discoveryUrl" class="text medium-long-field required" autocomplete="off">
+                <div class="error" id="discoveryUrlError"></div>
+                <div class="description">OIDC Discovery endpoint, e.g. https://idp.com/.well-known/openid-configuration</div>
+            </div>
+            <div class="field-group">
+                <label for="oidcClientId">OIDC Client ID<span class="aui-icon icon-required"></span></label>
+                <input type="text" id="oidcClientId" name="oidcClientId" class="text medium-long-field required" autocomplete="off">
+                <div class="error" id="oidcClientIdError"></div>
+                <div class="description">OIDC Client ID configured in Octane SSO (sso.conf)</div>
+            </div>
+            <div class="field-group">
+                <label for="oidcClientSecret">OIDC Client Secret<span class="aui-icon icon-required"></span></label>
+                <input type="password" id="oidcClientSecret" name="oidcClientSecret" class="text medium-long-field required" autocomplete="off">
+                <div class="error" id="oidcClientSecretError"></div>
+                <div class="description">OIDC Client Secret configured in Octane SSO (sso.conf)</div>
+            </div>
+            <div class="field-group">
                 <div id="button-group" style="position: relative;">
                     <input type="button" class="aui-button" id="dialog-test-space-connection" value="Test connection">
                     <span id="space-save-status" class="aui-icon aui-icon-small"></span>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3011011

- in UI: 
    - implemented a new UI for OIDC 
    - if OIDC is enabled, the user has to configure the OIDC discovery url and the OIDC client id and secret found in octane.sso

- in the server side:
    - Added method to configure OIDC settings on the server side
    - Fetches the OIDC discovery document to get the token endpoint.
    - Calls the token endpoint with client credentials to get an IDP access token.
    - Exchanges the IDP access token at the Octane /oauth/token endpoint to get an Octane access token.
    - Stores the Octane access token as a cookie for future requests.
    - Integrated automatic OIDC token refresh when authentication fails
    
<img width="1248" height="802" alt="image" src="https://github.com/user-attachments/assets/69273699-0e7d-44a2-9b10-6a50250ddc3d" />
